### PR TITLE
Support GNU formatted device ids

### DIFF
--- a/needrestart
+++ b/needrestart
@@ -242,13 +242,18 @@ for my $pid (@pids) {
 	    # get on-disk info
 	    my ($sdev, $sinode) = stat($path);
 	    last unless(defined($sinode));
-	    $sdev = sprintf("%02x:%02x", $sdev >> 8, $sdev & 0xff);
+		my @sdevs = (
+			# glibc gnu_dev_* definition from sysmacros.h
+			sprintf("%02x:%02x", (($sdev >> 8) & 0xfff) | (($sdev >> 32) & ~0xfff), (($sdev & 0xff) | (($sdev >> 12) & ~0xff))),
+			# Traditional definition of major(3) and minor(3)
+			sprintf("%02x:%02x", $sdev >> 8, $sdev & 0xff)
+		);
 	    
 	    # compare maps content vs. on-disk
-	    if($mdev ne $sdev || $minode ne $sinode) {
-		print STDERR "#$pid uses obsolete $path\n" if($nrconf{verbose});
-		$restart++;
-		last;
+		unless($mdev ~~ @sdevs && $minode eq $sinode) {
+			print STDERR "#$pid uses obsolete $path\n" if($nrconf{verbose});
+			$restart++;
+			last;
 	    }
 	}
 	close(HMAP);


### PR DESCRIPTION
glibc uses a different definition of the major/minor part of device numbers:

``` C
unsigned int gnu_dev_major (unsigned long long int __dev) {
    return ((__dev >> 8) & 0xfff) | ((unsigned int) (__dev >> 32) & ~0xfff);
}

unsigned int gnu_dev_minor (unsigned long long int __dev) {
    return (__dev & 0xff) | ((unsigned int) (__dev >> 12) & ~0xff);
}
```

I have added support for this format by checking both formats against the string from the `maps` file. I don't believe that name collisions (and device changes) are likely enough to justify a more elaborate approach.

Also, on my system, procfs prepends `(deleted)` to removed files in the `maps` file. I've added a line to removed that. It doesn't make much of a difference, because the path does still either not exist or will have a different inode, but it looks better this way IMHO.
