### PR TITLE
Fix ReadKey warning due to progress bar ioctl if the process has no controlling TTY

### DIFF
--- a/perl/lib/NeedRestart/UI.pm
+++ b/perl/lib/NeedRestart/UI.pm
@@ -109,7 +109,7 @@ sub _progress_inc {
 sub _progress_out {
     my $self = shift;
     
-    my ($columns) = GetTerminalSize(\*STDOUT);
+    my ($columns) = (-t \*STDOUT) ? GetTerminalSize(\*STDOUT) : 80;
     
     $columns -= 3;
     my $wmsg = int($columns * 0.7);
@@ -124,7 +124,7 @@ sub _progress_fin {
 
    $self->{progress}->{count} = 0;
 
-   my ($columns) = GetTerminalSize(\*STDOUT);
+   my ($columns) = (-t \*STDOUT) ? GetTerminalSize(\*STDOUT) : 80;
 
    print $self->{progress}->{msg}, ' ' x ($columns - length($self->{progress}->{msg})), "\n";
 }


### PR DESCRIPTION
If needrestart runs without a controlling TTY, e.g. from unattended-upgrades, the progress bar still tries to run `GetTerminalSize()`, which prints a warning

```
Unable to get Terminal Size. The TIOCGWINSZ ioctl didn't work. The COLUMNS and LINES environment variables didn't work. The resize program didn't work. at /usr/lib/perl5/Term/ReadKey.pm line 362.
```

I originally reported this as [Debian bug 768124](https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=768124), but the resolution didn't work for me. This pull request fixes the problem by using a default progress indicator width if `/dev/tty` cannot be opened (or, more precise, isn't a terminal).

You can use this Python script to trigger the warning:

``` python
import os, sys
(fread, fwrite) = os.pipe()
if os.fork() == 0:
    os.setsid()
    os.close(1)
    os.close(2)
    os.dup2(fwrite, 1)
    os.dup2(fwrite, 2)
    os.close(0)
    if os.fork() == 0:
        os.execlp("needrestart", "needrestart")
    sys.exit(0)
f = os.fdopen(fread, "r")
while True:
    l = f.readline()
    print l.replace("\033", "^[")
```
