### PR TITLE
Change exit codes to use needrestart as nagios-plugin

### DIFF
--- a/needrestart
+++ b/needrestart
@@ -122,6 +122,8 @@ unless(getopts('c:vr:nbf:kl')) {
     exit 1;
 }
 
+our $need_kernel_restart = 0;
+
 # restore ARGV
 @ARGV = @argv;
 
@@ -587,10 +589,12 @@ if(defined($opt_k)) {
 	}
 	else {
 	    if($kresult == NRK_NOUPGRADE) {
-		$ui->notice('Running kernel seems to be up-to-date.');
+    		$ui->notice('Running kernel seems to be up-to-date.');
+            $need_kernel_restart = 1;
 	    }
 	    elsif($kresult == NRK_ABIUPGRADE) {
-		$ui->announce_abi(%kvars);
+    		$ui->announce_abi(%kvars);
+            $need_kernel_restart = 1;
 	    }
 	    elsif($kresult == NRK_VERUPGRADE) {
 		$ui->announce_ver(%kvars);
@@ -607,93 +611,105 @@ if(defined($opt_l) && !$uid) {
 	$ui->notice('No services need to be restarted.') unless($opt_b);
     }
     else {
-	if($opt_b || $opt_r ne 'i') {
-	    $ui->notice('Services to be restarted:');
-	    
-	    foreach my $rc (sort { lc($a) cmp lc($b) } keys %restart) {
-		if($opt_b) {
-		    print "NEEDRESTART-SVC: $rc\n";
-		    next;
-		}
+    	if($opt_b || $opt_r ne 'i') {
+    	    $ui->notice('Services to be restarted:');
+    	    
+    	    foreach my $rc (sort { lc($a) cmp lc($b) } keys %restart) {
+        		if($opt_b) {
+        		    print "NEEDRESTART-SVC: $rc\n";
+        		    next;
+        		}
 
-		# don't restart greylisted services...
-		my $restart = !$nrconf{defno};
-		foreach my $re (keys %{$nrconf{override_rc}}) {
-		    next unless($rc =~ /$re/);
+        		# don't restart greylisted services...
+        		my $restart = !$nrconf{defno};
+        		foreach my $re (keys %{$nrconf{override_rc}}) {
+        		    next unless($rc =~ /$re/);
 
-		    $restart = $nrconf{override_rc}->{$re};
-		    last;
-		}
-		# ...but complain about them
-		unless($restart) {
-		    $ui->notice("Skipping $rc...");
-		    next;
-		}
+        		    $restart = $nrconf{override_rc}->{$re};
+        		    last;
+        		}
+        		# ...but complain about them
+        		unless($restart) {
+        		    $ui->notice("Skipping $rc...");
+        		    next;
+        		}
 
-		my @cmd = restart_cmd($rc);
-		next unless($#cmd > -1);
+        		my @cmd = restart_cmd($rc);
+        		next unless($#cmd > -1);
 
-		if($opt_r eq 'a') {
-		    system(@cmd);
-		}
-		else {
-		    $ui->notice(join(' ', @cmd));
-		}
-	    }
-	
-	    unless($opt_b || $#systemd_restart == -1) {
-		my @cmd = (qq(systemctl), qq(restart), @systemd_restart);
-		if($opt_r eq 'a') {
-		    $ui->notice('Restarting services using systemd...');
-		    system(@cmd);
-		}
-		else {
-		    $ui->notice(join(' ', @cmd));
-		}
-	    }
-	}
-	else {
-	    my $o = 0;
+        		if($opt_r eq 'a') {
+        		    system(@cmd);
+        		}
+        		else {
+        		    $ui->notice(join(' ', @cmd));
+        		}
+    	    }
+    	
+    	    unless($opt_b || $#systemd_restart == -1) {
+        		my @cmd = (qq(systemctl), qq(restart), @systemd_restart);
+        		if($opt_r eq 'a') {
+        		    $ui->notice('Restarting services using systemd...');
+        		    system(@cmd);
+        		}
+        		else {
+        		    $ui->notice(join(' ', @cmd));
+        		}
+    	    }
+    	}
+    	else {
+    	    my $o = 0;
 
-	    $ui->query_pkgs('Services to be restarted:', $nrconf{defno}, \%restart, $nrconf{override_rc},
-			    sub {
-				my @cmd = restart_cmd(shift);
-				system(@cmd) if($#cmd > -1);
-			    });
+    	    $ui->query_pkgs('Services to be restarted:', $nrconf{defno}, \%restart, $nrconf{override_rc},
+    			    sub {
+    				my @cmd = restart_cmd(shift);
+    				system(@cmd) if($#cmd > -1);
+    			    });
 
-	    if($#systemd_restart > -1) {
-		$ui->notice('Restarting services using systemd...');
-		system(qq(systemctl), qq(restart), @systemd_restart);
-	    }
-	}
+    	    if($#systemd_restart > -1) {
+    		$ui->notice('Restarting services using systemd...');
+    		system(qq(systemctl), qq(restart), @systemd_restart);
+    	    }
+    	}
     }
 
     # list and notify user sessions
     if(scalar keys %sessions) {
-	$ui->notice('User sessions:');
-	foreach my $uid (sort { ncmp(uid2name($a), uid2name($b)); } keys %sessions) {
-	    foreach my $sess (sort keys %{ $sessions{$uid} }) {
-		my $fnames = join(', ',map { $_.'['.join(',', @{ $sessions{$uid}->{$sess}->{$_} }).']';  } nsort keys %{ $sessions{$uid}->{$sess} });
-		$ui->notice(uid2name($uid)." on $sess is running obsolete $fnames");
-		if($nrconf{sendnotify}) {
-		    local %ENV;
+    	$ui->notice('User sessions:');
+    	foreach my $uid (sort { ncmp(uid2name($a), uid2name($b)); } keys %sessions) {
+    	    foreach my $sess (sort keys %{ $sessions{$uid} }) {
+        		my $fnames = join(', ',map { $_.'['.join(',', @{ $sessions{$uid}->{$sess}->{$_} }).']';  } nsort keys %{ $sessions{$uid}->{$sess} });
+        		$ui->notice(uid2name($uid)." on $sess is running obsolete $fnames");
+        		if($nrconf{sendnotify}) {
+        		    local %ENV;
 
-		    $ENV{NR_UID} = $uid;
-		    $ENV{NR_USERNAME} = uid2name($uid);
-		    $ENV{NR_SESSION} = $sess;
-		    $ENV{NR_SESSPPID} = findppid($uid, sort map { @$_; } values %{ $sessions{$uid}->{$sess} });
+        		    $ENV{NR_UID} = $uid;
+        		    $ENV{NR_USERNAME} = uid2name($uid);
+        		    $ENV{NR_SESSION} = $sess;
+        		    $ENV{NR_SESSPPID} = findppid($uid, sort map { @$_; } values %{ $sessions{$uid}->{$sess} });
 
-		    foreach my $bin (nsort <$nrconf{notify_d}/*>) {
-			next unless(-x $bin);
-			next if($bin =~ /(~|\.dpkg-[^.]+)$/);
+        		    foreach my $bin (nsort <$nrconf{notify_d}/*>) {
+        			next unless(-x $bin);
+        			next if($bin =~ /(~|\.dpkg-[^.]+)$/);
 
-			print STDERR "$LOGPREF run $bin\n" if($nrconf{verbose});
-			my $pipe = nr_fork_pipew($nrconf{verbose}, $bin);
-			print $pipe "$fnames\n";
-			last if(close($pipe));
-		    }
-		}
-	    }
-	}
+        			print STDERR "$LOGPREF run $bin\n" if($nrconf{verbose});
+        			my $pipe = nr_fork_pipew($nrconf{verbose}, $bin);
+        			print $pipe "$fnames\n";
+        			last if(close($pipe));
+        		    }
+        		}
+    	    }
+    	}
     }
+
+    if(($opt_r eq 'l') && $opt_b) {
+        if (scalar(%restart) gt 0) {
+            print "Need Daemons restart !\n";
+            exit(2);
+        }
+        elsif($need_kernel_restart) {
+            print "Need Kernel restart !\n";
+            exit(1);
+        }
+    }
+    exit(0);
 }


### PR DESCRIPTION
hi,

`needrestart` is an useful piece of code to track daemons need to be started after a security update.
The only thing we missed, is to use needrestart as nagios-plugin, to receive alerts in Shinken/Tanto/Nagios/Icinga...
The only thing we need is that needrestart returns an exit code different to 0 when you have kernel or libraries upgrades: https://nagios-plugins.org/doc/guidelines.html#RETURNCODES
By convention, we use 1 for kernel restart and 2 for daemons restart, because daemons restart is often critical for security compare to kernel security alerts, the kernel exploits are very often only locally exploitable, compare to daemons like with openssl security upgrades.
This pull request is a quick'n'dirty fix to add several exit codes with needrestart, we aren't Perl specialists, we're a Python company.
If you want to reimplement this feature, or give us some tips to improve our pull request, feel free.
Nevertheless, this feature should interest people that monitor with security-minded their infrastructure.

Regards.