### PR TITLE
Added missing semicolon.

### DIFF
--- a/ex/needrestart.conf
+++ b/ex/needrestart.conf
@@ -92,7 +92,7 @@ $nrconf{override_rc} = {
 #$nrconf{interpscan} = 0;
 
 # Disable hints on pending kernel upgrades.
-#$nrconf{kernelhints} = 0
+#$nrconf{kernelhints} = 0;
 
 # Read additional config snippets.
 if(-d q(/etc/needrestart/conf.d)) {


### PR DESCRIPTION
In the example needrestart.conf a semicolon is missing. Users just uncommenting the line could overlook the missing semicolon, since this is usually not needed in configuration files.