### PR TITLE
Fix version number in NeedRestart.pm

### DIFF
--- a/perl/lib/NeedRestart.pm
+++ b/perl/lib/NeedRestart.pm
@@ -77,7 +77,7 @@ our %EXPORT_TAGS = (
     )],
 );
 
-our $VERSION = '2.1';
+our $VERSION = '2.4';
 my $LOGPREF = '[Core]';
 
 my %UIs;


### PR DESCRIPTION
The version number in `perl/lib/NeedRestart.pm` is still `2.1`. I've
updated it to `2.4` for the next release.