### PR TITLE
added check if init file is a symlink to upstart

### DIFF
--- a/needrestart
+++ b/needrestart
@@ -195,6 +195,13 @@ sub parse_lsbinit($) {
     my $rc = '/etc/init.d/'.shift;
     my %lsb;
 
+    if ( -l $rc) {
+        if (readlink($rc) eq '/lib/init/upstart-job') {
+	    print STDERR "WARNING: $rc is a converted upstart job.\n";
+	    return ();
+	}
+    }
+
     open(HLSB, '<', $rc) || die "Can't open $rc: $!\n";
     my $found;
     while(my $line = <HLSB>) {


### PR DESCRIPTION
on Ubuntu 14.04 with needrestart 2.6 without the patch:

Scanning processes...
WARNING: /etc/init.d/cron has no LSB tags!===
Odd number of elements in hash assignment at /usr/sbin/needrestart line
556, <HLSB> line 119.
Use of uninitialized value in list assignment at /usr/sbin/needrestart
line 556, <HLSB> line 119.
Scanning candidates...
Scanning linux images...
Running kernel seems to be up-to-date.
Services to be restarted:

ls -al /etc/init.d/cron
lrwxrwxrwx 1 root root 21 Dec 15  2014 /etc/init.d/cron -> /lib/init/upstart-job

the new code will check if the init script is a symlink and the symlink
points to /lib/init/upstart-job.