### PR TITLE
Allow systemd service names with dots in them.

### DIFF
--- a/needrestart
+++ b/needrestart
@@ -517,7 +517,7 @@ if(defined($opt_l)) {
 		my $ret = <$systemctl>;
 		close($systemctl);
 
-		if(defined($ret) && $ret =~ /([^.\s]+\.service) /) {
+		if(defined($ret) && $ret =~ /([^\s]+\.service) /) {
 		    my $s = $1;
 		    print STDERR "$LOGPREF #$pid is $s\n" if($nrconf{verbosity} > 1);
 		    $restart{$s}++;


### PR DESCRIPTION
This has solved the parsing of services like `php5.6-fpm.service` which showed
up as `6-fpm.service` for me.