### PR TITLE
Use $(MAKE) instead of make for parallel make

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -64,5 +64,5 @@ po/needrestart-notify/messages.pot: ex/notify.d/*-*
 
 
 mo-files:
-	make -C po/needrestart
-	make -C po/needrestart-notify
+	$(MAKE) -C po/needrestart
+	$(MAKE) -C po/needrestart-notify


### PR DESCRIPTION
Discovered at https://bugs.gentoo.org/show_bug.cgi?id=588216