### PR TITLE
Introduce blacklist_interp to allow ignoring of interpreted files

### DIFF
--- a/needrestart
+++ b/needrestart
@@ -112,6 +112,7 @@ our %nrconf = (
     ui_mode => 'a',
     systemctl_combine => 0,
     blacklist => [],
+    blacklist_interp => [],
     blacklist_rc => [],
     override_rc => [],
     override_cont => [],
@@ -484,7 +485,7 @@ if(defined($opt_l)) {
 	}
 
 	unless($restart || !$nrconf{interpscan}) {
-	    $restart++ if(needrestart_interp_check($nrconf{verbosity} > 1, $pid, $exe));
+	    $restart++ if(needrestart_interp_check($nrconf{verbosity} > 1, $pid, $exe, $nrconf{blacklist_interp}));
 	}
 
 	# handle containers (LXC, docker, etc.)

--- a/perl/lib/NeedRestart.pm
+++ b/perl/lib/NeedRestart.pm
@@ -155,10 +155,11 @@ sub needrestart_interp_init($) {
     }
 }
 
-sub needrestart_interp_check($$$) {
+sub needrestart_interp_check($$$$) {
     my $debug = shift;
     my $pid = shift;
     my $bin = shift;
+    my $blacklist = shift;
 
     needrestart_interp_init($debug) unless(%Interps);
 
@@ -168,6 +169,12 @@ sub needrestart_interp_check($$$) {
 
 	    my $ps = nr_ptable_pid($pid);
 	    my %files = $interp->files($pid, \%InterpCache);
+
+	    foreach my $path (keys %files) {
+		next unless(scalar grep { $path =~ /$_/; } @{$blacklist});
+		print  STDERR "$LOGPREF blacklisted: $path\n" if($debug);
+		delete($files{$path});
+	    }
 
 	    if(grep {!defined($_) || $_ > $ps->start} values %files) {
 		if($debug) {


### PR DESCRIPTION
My use case: running needrestart via ansible shows sometimes false positives for /tmp/ansible_* files, finding parent sshd -> wants to restart ssh.service more often than necessary.