### PR TITLE
[Conf] Add libvirt to override_rc

### DIFF
--- a/ex/needrestart.conf
+++ b/ex/needrestart.conf
@@ -111,6 +111,7 @@ $nrconf{override_rc} = {
     qr(^mythtv-backend) => 0,
     qr(^xendomains) => 0,
     qr(^lxcfs) => 0,
+    qr(^libvirt) => 0,
 
     # workaround for broken systemd-journald
     # (see also Debian Bug#771122 & #771254)


### PR DESCRIPTION
Since other VMs systems are not restarted, libvirt shouldn't be either.

See https://github.com/liske/needrestart/commit/2e3fd0c52dac295779add0fad5ca25418193065a and https://github.com/liske/needrestart/commit/e4bfba09bfdd2e6a11b5746751124deb80bbc20b