### PR TITLE
[Interp/Perl] add missing cwd restore before a return

### DIFF
--- a/perl/lib/NeedRestart/Interp/Perl.pm
+++ b/perl/lib/NeedRestart/Interp/Perl.pm
@@ -140,6 +140,7 @@ sub files {
 
     # use cached data if avail
     if(exists($cache->{files}->{(__PACKAGE__)}->{$src})) {
+	chdir($cwd);
 	print STDERR "$LOGPREF #$pid: use cached file list\n" if($self->{debug});
 	return %{ $cache->{files}->{(__PACKAGE__)}->{$src} };
     }


### PR DESCRIPTION
As requested in [#55](https://github.com/liske/needrestart/issues/55#issuecomment-313157362).