### PR TITLE
tell needrestart to not restart bird

### DIFF
--- a/ex/needrestart.conf
+++ b/ex/needrestart.conf
@@ -93,6 +93,7 @@ $nrconf{override_rc} = {
     qr(^lxdm) => 0,
 
     # networking stuff
+    qr(^bird) => 0,
     qr(^network-manager) => 0,
     qr(^NetworkManager) => 0,
     qr(^wpa_supplicant) => 0,


### PR DESCRIPTION
bird and bird6 are daemons like quagga.
When restartet they usually bring most routes of the networks down.
So better blacklist them.

Signed-off-by: Björn Lässig <b.laessig@pengutronix.de>