### PR TITLE
added missing 'abs_path' function calls

### DIFF
--- a/perl/lib/NeedRestart/Interp/Perl.pm
+++ b/perl/lib/NeedRestart/Interp/Perl.pm
@@ -129,7 +129,7 @@ sub files {
 	print STDERR "$LOGPREF #$pid: could not get a source file, skipping\n" if($self->{debug});
 	return ();
     }
-    my $src = $ARGV[0];
+    my $src = abs_path ($ARGV[0]);
     unless(-r $src && -f $src) {
 	chdir($cwd);
 	print STDERR "$LOGPREF #$pid: source file not found, skipping\n" if($self->{debug});

--- a/perl/lib/NeedRestart/Interp/Python.pm
+++ b/perl/lib/NeedRestart/Interp/Python.pm
@@ -160,7 +160,7 @@ sub files {
 	print STDERR "$LOGPREF #$pid: could not get a source file, skipping\n" if($self->{debug});
 	return ();
     }
-    my $src = $ARGV[0];
+    my $src = abs_path ($ARGV[0]);
     unless(-r $src && -f $src) {
 	chdir($cwd);
 	print STDERR "$LOGPREF #$pid: source file not found, skipping\n" if($self->{debug});


### PR DESCRIPTION
Hi,

we are trying to switch from checkrestart to needrestart and get quite a lot of differing results. I am currently investigating why. This patch fixes problems with Perl and Python scripts running as services. I found that without the patch some services which run as e.g.

python Launch.py

so with a script file with relative path name, needrestart cannot figure out the correct path name of the script to analyse it.

Cheers,

Christopher