### PR TITLE
Do not assume STDOUT is a terminal in NeedRestart::UI

### DIFF
--- a/perl/lib/NeedRestart/UI.pm
+++ b/perl/lib/NeedRestart/UI.pm
@@ -47,7 +47,7 @@ sub wprint {
     my $message = shift;
 
     # workaround Debian Bug#824564 in Term::ReadKey: pass filehandle twice
-    my ($cols) = GetTerminalSize($fh, $fh);
+    my ($cols) = GetTerminalSize($fh, $fh) if (-t $fh);
     $columns = $cols if($cols);
 
     print $fh wrap($sp1, $sp2, $message);

--- a/perl/lib/NeedRestart/UI/stdio.pm
+++ b/perl/lib/NeedRestart/UI/stdio.pm
@@ -42,7 +42,9 @@ sub _announce {
 					 kversion => $vars{KVERSION},
 					 message => $message,
 		   ));
-    <STDIN>;
+
+    # Expect user input only within a terminal
+    <STDIN> if (-t STDIN && -t STDOUT);
 }
 
 

--- a/perl/lib/NeedRestart/UI/stdio.pm
+++ b/perl/lib/NeedRestart/UI/stdio.pm
@@ -88,6 +88,8 @@ sub notice($$) {
     my $indent = ' ';
     $indent .= $1 if($out =~ /^(\s+)/);
 
+    return unless($self->{verbosity});
+
     $self->wprint(\*STDOUT, '', $indent, "$out\n");
 }
 


### PR DESCRIPTION
Fix #86

With this change, needrestart can run in unattended mode with the following command: 

`needrestart -u NeedRestart::UI::stdio -q -r l | logger -s`