### PR TITLE
Respect verbosity in UI::stdio, just like UI::Debconf

### DIFF
--- a/perl/lib/NeedRestart/UI/stdio.pm
+++ b/perl/lib/NeedRestart/UI/stdio.pm
@@ -83,6 +83,9 @@ EHINT
 sub notice($$) {
     my $self = shift;
     my $out = shift;
+
+    return unless($self->{verbosity});
+
     my $indent = ' ';
     $indent .= $1 if($out =~ /^(\s+)/);
 


### PR DESCRIPTION
This is an helpful change for the unattended use case, where cron runs needrestart. 

With the quiet mode correctly applied, the following produces no output when everything is up-to-date, which is was you'd want for a cron task: 

`needrestart -u NeedRestart::UI::stdio -q -r l`