### PR TITLE
output NRPE message "root needed" on stdout

### DIFF
--- a/needrestart
+++ b/needrestart
@@ -199,7 +199,7 @@ print STDERR "$LOGPREF needrestart v$NeedRestart::VERSION\n" if($nrconf{verbosit
 my $uid = $<;
 if($uid) {
     if($opt_p) {
-	print STDERR "UNKN - This plugin needs to be run as root!\n";
+	print "UNKN - This plugin needs to be run as root!\n";
 	exit 3;
     }
 


### PR DESCRIPTION
Messages on stderr are ignored by NRPE protocol. That message was never transmitted to the caller. Caller just said "Unable to read output".

See https://bugs.debian.org/881043