### PR TITLE
Fix override_rc being used when querying containers

### DIFF
--- a/needrestart
+++ b/needrestart
@@ -1052,7 +1052,7 @@ if(defined($opt_l) && !$uid) {
 	    my $o = 0;
 
 	    $ui->notice(__ 'Restarting containers...');
-	    $ui->query_conts(__('Containers to be restarted:'), $nrconf{defno}, \%conts, $nrconf{override_rc},
+	    $ui->query_conts(__('Containers to be restarted:'), $nrconf{defno}, \%conts, $nrconf{override_cont},
 			     sub {
 				 my $cont = shift;
 				 $ui->command(join(' ', '', @{ $conts{$cont} }));


### PR DESCRIPTION
We're dealing with containers at this stage, not services.

We should probably be using override_cont not override_rc.

Signed-off-by: Nigel Kukard <nkukard@lbsd.net>