### PR TITLE
[Kernel] Include /boot/kernel* while looking for linux kernel images

### DIFF
--- a/perl/lib/NeedRestart/Kernel/Linux.pm
+++ b/perl/lib/NeedRestart/Kernel/Linux.pm
@@ -131,7 +131,7 @@ sub nr_kernel_check_real($$) {
     } grep {
 	# filter initrd images
 	(!m@^/boot/init@);
-    } (</boot/vmlinu*>, </boot/*.img>);
+    } (</boot/vmlinu*>, </boot/*.img>, </boot/kernel*>);
 
     $ui->progress_prep(scalar keys %kfiles, __ 'Scanning linux images...');
 


### PR DESCRIPTION
Fixes kernel detection on Gentoo

Originally reported at https://bugs.gentoo.org/654958