### PR TITLE
Do not restart ModemManager by default

### DIFF
--- a/ex/needrestart.conf
+++ b/ex/needrestart.conf
@@ -100,6 +100,7 @@ $nrconf{override_rc} = {
     qr(^bird) => 0,
     qr(^network-manager) => 0,
     qr(^NetworkManager) => 0,
+    qr(^ModemManager) => 0,
     qr(^wpa_supplicant) => 0,
     qr(^openvpn) => 0,
     qr(^quagga) => 0,


### PR DESCRIPTION
It teardowns the current modem connection even without restarting NetworkManager.