### PR TITLE
Verify that a file is executable before returning it as RC script

### DIFF
--- a/hooks/20-rpm
+++ b/hooks/20-rpm
@@ -71,9 +71,9 @@ exit(0) unless($#pkgs > -1);
 foreach my $pkg (@pkgs) {
     print "PACKAGE|$pkg\n";
 
-    my $plist = fork_pipe(qw(rpm -q --filesbypkg), $pkg);
+    my $plist = fork_pipe(qw(rpm -q --queryformat), '[%{FILENAMES} %{FILEMODES:perms}\n]', $pkg);
     while(<$plist>) {
-	print "RC|$2\n" if(m@^\S+\s+/etc(/rc\.d)?/init\.d/(.+)$@);
+	print "RC|$2\n" if(m@^/etc(/rc\.d)?/init\.d/(.+)\s+...x@);
     }
     close($plist);
 }


### PR DESCRIPTION
While this is a just a harmless warning, needrestart on Centos 7
return the following message:

    WARNING: /etc/init.d/README has no LSB tags!

I narrowed it to the following invocation:

    # /etc/needrestart/hook.d/20-rpm /etc/init.d/README
    PACKAGE|systemd-219-57.el7.x86_64
    RC|README

Since /etc/init.d/README is not a init script (not executable), it
shouldn't be listed as such