### PR TITLE
fix "Can't cd to (unreachable)" error

### DIFF
--- a/perl/lib/NeedRestart/Interp/Perl.pm
+++ b/perl/lib/NeedRestart/Interp/Perl.pm
@@ -167,6 +167,7 @@ sub files {
 	# Silence warnings of Module::ScanDeps for dynamic loaded modules (github issue #41)
 	local $SIG{__WARN__} = sub { };
 
+        chdir($cwd);
 	$href = scan_deps(
 	    files => [$src],
 	    recurse => 1,


### PR DESCRIPTION
Hi,

one of our Debian stretch machines made needrestart crash with the error

root@bilbo[~]# needrestart -v
[main] eval /etc/needrestart/needrestart.conf
[main] needrestart v3.3
[main] running in root mode
[Core] Using UI 'NeedRestart::UI::stdio'...
[main] systemd detected
[Core] #598 is a NeedRestart::Interp::Python
[Python] #598: source=/usr/local/sbin/bcfg2-push
[Core] #11905 is a NeedRestart::Interp::Perl
[Perl] #11905: source=/usr/local/bin/apache-vsl
Can't cd to (unreachable)/etc/apache2: No such file or directory

After some digging I found that just before the call to 'scan_deps' the working dir is "(unreachable)/something". A simple chdir ($cwd) just before the call fixed this.

The issues #55 and #72 look quite similar, maybe this patch would have fixed them as well.

Thanks,

Christopher