### PR TITLE
Parse output of old iucode-tool 1.5.

### DIFF
--- a/perl/lib/NeedRestart/uCode/Intel.pm
+++ b/perl/lib/NeedRestart/uCode/Intel.pm
@@ -70,9 +70,9 @@ sub nr_ucode_check_real {
 
     my $fh = nr_fork_pipe($debug, NRM_INTEL_HELPER, $debug);
     while(<$fh>) {
-        if (/\s+\d+\/\d+: sig.+, rev (0x[\da-f]+),/) {
-            $vars{AVAIL} = sprintf("0x%x", hex($1));
-            print STDERR "$LOGPREF available revision: $1\n" if($debug);
+        if (/\s*\d+(\/\d+)?: sig.+, rev (0x[\da-f]+),/) {
+            $vars{AVAIL} = sprintf("0x%x", hex($2));
+            print STDERR "$LOGPREF available revision: $2\n" if($debug);
             next;
         }
     }


### PR DESCRIPTION
When using your actual version 3.3 on Ubuntu 16.04 (xenial), checking for obsolete CPU microcode fails.

The source of this problem is the different output format of the old version of iucode-tool (1.5.1), which is used in xenial.

```
$ iucode_tool -l -s 0x00020655,0x10 -tb /lib/firmware/intel-ucode
selected microcodes:
001: sig 0x00020655, pf mask 0x92, 2018-04-23, rev 0x0007, size 4096
```