### PR TITLE
[Conf] add FRR to restart blacklist

### DIFF
--- a/ex/needrestart.conf
+++ b/ex/needrestart.conf
@@ -104,6 +104,7 @@ $nrconf{override_rc} = {
     qr(^wpa_supplicant) => 0,
     qr(^openvpn) => 0,
     qr(^quagga) => 0,
+    qr(^frr) => 0,
     qr(^tinc) => 0,
     qr(^(open|free|libre|strong)swan) => 0,
 


### PR DESCRIPTION
frr (service name for the FRRouting suite) falls in the same category as
Quagga and BIRD.