### PR TITLE
Add network.service in the blacklist

### DIFF
--- a/ex/needrestart.conf
+++ b/ex/needrestart.conf
@@ -98,7 +98,9 @@ $nrconf{override_rc} = {
 
     # networking stuff
     qr(^bird) => 0,
-    qr(^network-manager) => 0,
+    # network-manager but also the network service
+    # (used on Red Hat systems without NetworkManager)
+    qr(^network) => 0,
     qr(^NetworkManager) => 0,
     qr(^ModemManager) => 0,
     qr(^wpa_supplicant) => 0,


### PR DESCRIPTION
On Red Hat systems without NetworkManager installed, this service
handles network configuration and MUST NOT be restarted.