### PR TITLE
Fix needrestart.conf comment to mention the correct default

### DIFF
--- a/ex/needrestart.conf
+++ b/ex/needrestart.conf
@@ -165,8 +165,8 @@ $nrconf{blacklist_mappings} = [
 ];
 
 # Verify mapped files in fileystem:
-# 0 : enabled (default)
-# -1: ignore non-existing files, workaround for chroots and broken grsecurity kernels
+# 0 : enabled
+# -1: ignore non-existing files, workaround for chroots and broken grsecurity kernels (default)
 # 1 : disable check completely, rely on content of maps file only
 $nrconf{skip_mapfiles} = -1;
 


### PR DESCRIPTION
Minor update for 4271153ee6d93f1b3ccccd6985069580916ef706 which had set the default to `-1` but missed to update the comment.