### PR TITLE
Make source path absolute for Ruby scripts

### DIFF
--- a/perl/lib/NeedRestart/Interp/Ruby.pm
+++ b/perl/lib/NeedRestart/Interp/Ruby.pm
@@ -171,7 +171,7 @@ sub files {
 	print STDERR "$LOGPREF #$pid: could not get a source file, skipping\n" if($self->{debug});
 	return ();
     }
-    my $src = $ARGV[0];
+    my $src = abs_path($ARGV[0]);
     unless(-r $src && -f $src) {
 	chdir($cwd);
 	print STDERR "$LOGPREF #$pid: source file '$src' not found, skipping\n" if($self->{debug});


### PR DESCRIPTION
I've noticed that needrestart always detects Ruby programs started with a relative path as to be restarted. When comparing the Ruby to the Perl or Python module, it looked like there's a missing call to `abs_path()` for the source path. Inserting the call resolves my issue.

Please let me know if there's anything else I need to do.