### PR TITLE
Fixes for LXC / LXD container support

### DIFF
--- a/README.Cont.md
+++ b/README.Cont.md
@@ -21,11 +21,13 @@ within docker containers by design.
 NeedRestart::CONT::LXC
 ----------------------
 
-Recognized by:	cgroup path (`/lxc/*`)
+Recognized by:	cgroup path (`/lxc/*` || `/lxc.payload/*`)
 
 For each container which should be restarted needrestart calls
 `lxc-stop --reboot --name $NAME`.
 
+This package also supports LXD containers, which are restarted by `lxc restart
+$NAME` or `lxc restart --project=$PROJECT $NAME` for containers in projects.
 
 NeedRestart::CONT::machined
 ---------------------------

--- a/perl/lib/NeedRestart/CONT/LXC.pm
+++ b/perl/lib/NeedRestart/CONT/LXC.pm
@@ -101,10 +101,20 @@ sub check {
 sub get {
     my $self = shift;
 
+    sub lxd_restart_with_project {
+	my ($bin, $container) = @_;
+	my @parts = split(/_/, $container);
+	if ($#parts == 1) {
+	    return [ $bin, 'restart', qq(--project=$parts[0]), $parts[1] ];
+	} else {
+	    [ $bin, 'restart', $container ]
+	}
+    }
+
     return (map {
 	($_ => [qw(lxc-stop --reboot --name), $_]);
     } keys %{ $self->{lxc} }), (map {
-	($_ => [ $self->{lxd_bin}, "restart", $_]);
+	($_ => lxd_restart_with_project($self->{lxd_bin}, $_));
     } keys %{ $self->{lxd} });
 }
 

--- a/perl/lib/NeedRestart/CONT/LXC.pm
+++ b/perl/lib/NeedRestart/CONT/LXC.pm
@@ -81,7 +81,7 @@ sub check {
     }
 
     # look for LXC cgroups
-    return unless($cg =~ /^\d+:[^:]+:\/lxc\/([^\/\n]+)($|\/)/m);
+    return unless($cg =~ /^\d+:[^:]+:\/lxc(?:.payload)?\/([^\/\n]+)($|\/)/m);
 
     my $name = $1;
     my $type = ($self->{has_lxd} && -d qq($self->{lxd_container_path}/$name) ? 'LXD' : 'LXC');


### PR DESCRIPTION
Support LXD installed via snapd, which is the recommended installation method.

Update the regex for matching container cgroups (since LXC 3.1, containers have separate lxc.payload and lxc.monitor cgroups for the container processes and the monitor).

Recognise containers in LXD projects (added in LXD 4.0) and generate the proper command to restart them.