### PR TITLE
systemd-manager restart: Support also exe => /usr/lib/systemd/systemd

### DIFF
--- a/needrestart
+++ b/needrestart
@@ -623,7 +623,7 @@ if(defined($opt_l)) {
 
 	    if($is_systemd) {
 		# systemd manager
-		if($pid == 1 && $exe =~ m@^/lib/systemd/systemd@) {
+		if($pid == 1 && $exe =~ m@^(/usr)?/lib/systemd/systemd@) {
 		    print STDERR "$LOGPREF #$pid is systemd manager\n" if($nrconf{verbosity} > 1);
 		    $restart{q(systemd-manager)}++;
 		    next;


### PR DESCRIPTION
In some cases especially Ubuntu 20.4 focal fossa the systemd process is
/usr/lib/systemd/systemd not /lib/systemd/systemd. That leads to
/etc/needrestart/restart.d/systemd-manager not beeing triggered.