### PR TITLE
needrestart.conf: Fix verbose/verbosity confusion

### DIFF
--- a/ex/needrestart.conf
+++ b/ex/needrestart.conf
@@ -206,7 +206,7 @@ $nrconf{skip_mapfiles} = -1;
 # Read additional config snippets.
 if(-d q(/etc/needrestart/conf.d)) {
       foreach my $fn (sort </etc/needrestart/conf.d/*.conf>) {
-	      print STDERR "$LOGPREF eval $fn\n" if($nrconf{verbose});
+	      print STDERR "$LOGPREF eval $fn\n" if($nrconf{verbosity} > 1);
 	      eval do { local(@ARGV, $/) = $fn; <>};
 	      die "Error parsing $fn: $@" if($@);
       }


### PR DESCRIPTION
The files included from conf.d were never printed to stderr, because the variable was misnamed.

Also, the comparison in the main program tests if the verbosity is >1