### PR TITLE
Don't restart the bluetooth service

### DIFF
--- a/ex/needrestart.conf
+++ b/ex/needrestart.conf
@@ -95,6 +95,7 @@ $nrconf{override_rc} = {
     qr(^frr) => 0,
     qr(^tinc) => 0,
     qr(^(open|free|libre|strong)swan) => 0,
+    qr(^bluetooth) => 0,
 
     # gettys
     qr(^getty@.+\.service) => 0,


### PR DESCRIPTION
Depending on how the system is configured, a restart of the bluetooth
service might result in a loss of network connectivity as well. Also,
it will disconnect bluetooth speakers/headphones, which is annoying
for the user.

With this commit, bluetooth is not restarted by default.