### PR TITLE
[UI] Make stdio noninteractive if DEBIAN_FRONTEND='noninteractive'

### DIFF
--- a/needrestart
+++ b/needrestart
@@ -190,6 +190,7 @@ die "ERROR: Could not read config file '$opt_c'!\n" unless(-r $opt_c || $opt_b);
 
 # override debconf frontend
 $ENV{DEBIAN_FRONTEND} = $opt_f if($opt_f);
+my $debian_noninteractive = (exists($ENV{DEBIAN_FRONTEND}) && $ENV{DEBIAN_FRONTEND} eq 'noninteractive');
 
 # be quiet
 if($opt_q) {
@@ -218,7 +219,7 @@ die "Hook directory '$nrconf{hook_d}' is invalid!\n" unless(-d $nrconf{hook_d} |
 $opt_r = $ENV{NEEDRESTART_MODE} if(!defined($opt_r) && exists($ENV{NEEDRESTART_MODE}));
 $opt_r = $nrconf{restart} unless(defined($opt_r));
 die "ERROR: Unknown restart option '$opt_r'!\n" unless($opt_r =~ /^(l|i|a)$/);
-$is_tty = 0 if($opt_r eq 'i' && exists($ENV{DEBIAN_FRONTEND}) && $ENV{DEBIAN_FRONTEND} eq 'noninteractive');
+$is_tty = 0 if($opt_r eq 'i' && $debian_noninteractive);
 $opt_r = 'l' if(!$is_tty && $opt_r eq 'i');
 
 $opt_m = $nrconf{ui_mode} unless(defined($opt_m));
@@ -263,6 +264,9 @@ if(defined($opt_u)) {
 
 my $ui = ($opt_b ? NeedRestart::UI->new(0) : needrestart_ui($nrconf{verbosity}, ($is_tty ? $nrconf{ui} : 'NeedRestart::UI::stdio')));
 die "Error: no UI class available!\n" unless(defined($ui));
+
+# Disable UI interactiveness
+$ui->interactive(0) if ($ui->can("interactive") && $debian_noninteractive);
 
 # enable/disable checks
 unless(defined($opt_k) || defined($opt_l) || defined($opt_w)) {

--- a/perl/lib/NeedRestart/UI/stdio.pm
+++ b/perl/lib/NeedRestart/UI/stdio.pm
@@ -33,6 +33,14 @@ use Locale::TextDomain 'needrestart';
 
 needrestart_ui_register(__PACKAGE__, NEEDRESTART_PRIO_LOW);
 
+# The default is to be interactive
+my $INTERACTIVE = 1;
+
+sub interactive {
+    my $self = shift;
+    $INTERACTIVE = shift;
+}
+
 sub _announce {
     my $self = shift;
     my $message = shift;
@@ -43,7 +51,7 @@ sub _announce {
 					 kversion => $vars{KVERSION},
 					 message => $message,
 		   ));
-    <STDIN> if (-t *STDIN && -t *STDOUT);
+    <STDIN> if (-t *STDIN && -t *STDOUT && $INTERACTIVE);
 }
 
 
@@ -77,7 +85,7 @@ You should consider rebooting!
 
 EHINT
 
-    <STDIN> if (-t *STDIN && -t *STDOUT);
+    <STDIN> if (-t *STDIN && -t *STDOUT && $INTERACTIVE);
 }
 
 
@@ -90,7 +98,7 @@ sub announce_ucode {
 			 current => $vars{CURRENT},
 			 avail => $vars{AVAIL},
 		   ));
-    <STDIN> if (-t *STDIN && -t *STDOUT);
+    <STDIN> if (-t *STDIN && -t *STDOUT && $INTERACTIVE);
 }
 
 


### PR DESCRIPTION
With DEBIAN_FRONTEND='noninteractive' NeedRestart::UI::stdio should not
prompt for user input.

Fixes #129
