### PR TITLE
Update LXC/D cgroup regex for LXC 4.0

### DIFF
--- a/perl/lib/NeedRestart/CONT/LXC.pm
+++ b/perl/lib/NeedRestart/CONT/LXC.pm
@@ -81,7 +81,7 @@ sub check {
     }
 
     # look for LXC cgroups
-    return unless($cg =~ /^\d+:[^:]+:\/lxc(?:.payload)?\/([^\/\n]+)($|\/)/m);
+    return unless($cg =~ /^\d+:[^:]+:\/lxc(?:.payload)?[.\/]([^\/\n]+)($|\/)/m);
 
     my $name = $1;
     my $type = ($self->{has_lxd} && -d qq($self->{lxd_container_path}/$name) ? 'LXD' : 'LXC');


### PR DESCRIPTION
LXC 4.0 uses a flattened cgroup hierarchy (/lxc.payload.container1 vs /lxc.payload/container1), update the regex to also match these names.