### PR TITLE
Add VM support

### DIFF
--- a/ex/needrestart.conf
+++ b/ex/needrestart.conf
@@ -108,6 +108,8 @@ $nrconf{override_rc} = {
     qr(^xendomains) => 0,
     qr(^lxcfs) => 0,
     qr(^libvirt) => 0,
+    qr(^virtlogd)} = 0,
+    qr(^virtlockd)} = 0,
     qr(^docker) => 0,
 
     # systemd stuff

--- a/needrestart
+++ b/needrestart
@@ -1300,7 +1300,7 @@ if(defined($opt_l) && !$uid) {
 			unless($opt_p || $opt_b) {
 				$ui->notice(__ 'VM guests are running outdated hypervisor (qemu) binaries on this host:');
 				foreach ( @guests ) {
-				$ui->notice(__ " $_");
+				$ui->notice(" $_");
 				}
 			}
 		}

--- a/needrestart
+++ b/needrestart
@@ -1290,7 +1290,7 @@ if(defined($opt_l) && !$uid) {
 	## GUESTS
 	$ui->vspace();
 	if (! @guests) {
-		$ui->notice(__ 'No VM guests are running outdated binaries.') unless($opt_b || $opt_m eq 'e');
+		$ui->notice(__ 'No VM guests are running outdated hypervisor (qemu) binaries on this host.') unless($opt_b || $opt_m eq 'e');
 	}
 	else {
 		if($opt_m eq 'e') {
@@ -1298,7 +1298,7 @@ if(defined($opt_l) && !$uid) {
 		}
 		else {
 			unless($opt_p || $opt_b) {
-				$ui->notice(__ 'VM guests running outdated binaries:');
+				$ui->notice(__ 'VM guests are running outdated hypervisor (qemu) binaries on this host:');
 				foreach ( @guests ) {
 				$ui->notice(__ " $_");
 				}

--- a/needrestart
+++ b/needrestart
@@ -670,7 +670,7 @@ if(defined($opt_l)) {
 								my @namearg = split(/=/, $_, 2);
 								if ($#{namearg} == 1) {
 									print STDERR "$LOGPREF #$pid detected as VM guest '$namearg[1]' in group '$value'\n" if($nrconf{verbosity} > 1);
-									push(@guests, "VM '$namearg[1]' with pid $pid" );
+									push(@guests, __x("'{name}' with pid {pid}", name => $namearg[1], pid=>$pid) );
 								}
 								next PIDLOOP;
 							}
@@ -678,7 +678,7 @@ if(defined($opt_l)) {
 					}
 				}
 				print STDERR "$LOGPREF #$pid detected as VM guest with unknown name in group '$value'\n" if($nrconf{verbosity} > 1);
-				push(@guests, "'Unkown VM' with pid $pid" );
+				push(@guests, __x("'Unkown VM' with pid {pid}", pid=>$pid) );
 				next;
 			    }
 			    elsif($value =~ m@/([^/]+\.service)$@) {

--- a/needrestart
+++ b/needrestart
@@ -441,6 +441,7 @@ print "NEEDRESTART-VER: $NeedRestart::VERSION\n" if($opt_b && !$opt_p);
 
 my %restart;
 my %sessions;
+my @guests;
 my @easy_hints;
 
 if(defined($opt_l)) {
@@ -617,7 +618,7 @@ if(defined($opt_l)) {
 
     if(scalar keys %stage2 && !$uid) {
 	$ui->progress_prep(scalar keys %stage2, __ 'Scanning candidates...');
-	foreach my $pid (sort {$a <=> $b} keys %stage2) {
+	PIDLOOP: foreach my $pid (sort {$a <=> $b} keys %stage2) {
 	    $ui->progress_step;
 
 	    # skip myself
@@ -659,6 +660,25 @@ if(defined($opt_l)) {
 			    if($value =~ m@/user\@(\d+)\.service@) {
 				print STDERR "$LOGPREF #$pid part of user manager service: uid=$1\n" if($nrconf{verbosity} > 1);
 				push(@{ $sessions{$1}->{'user manager service'}->{ $ptable->{$pid}->{fname} } }, $pid);
+				next;
+			    }
+				if($value =~ m@/machine.slice/machine.qemu(.*).scope@) {
+				for my $cmdlineidx (0 .. $#{$ptable->{$pid}->{cmdline}} ) {
+					if ( ${$ptable->{$pid}->{cmdline}}[$cmdlineidx] eq "-name") {
+						foreach ( split(/,/, ${$ptable->{$pid}->{cmdline}}[$cmdlineidx+1]) ) {
+							if ( index($_, "guest=") == 0 ) {
+								my @namearg = split(/=/, $_, 2);
+								if ($#{namearg} == 1) {
+									print STDERR "$LOGPREF #$pid detected as VM guest '$namearg[1]' in group '$value'\n" if($nrconf{verbosity} > 1);
+									push(@guests, "VM '$namearg[1]' with pid $pid" );
+								}
+								next PIDLOOP;
+							}
+						}
+					}
+				}
+				print STDERR "$LOGPREF #$pid detected as VM guest with unknown name in group '$value'\n" if($nrconf{verbosity} > 1);
+				push(@guests, "'Unkown VM' with pid $pid" );
 				next;
 			    }
 			    elsif($value =~ m@/([^/]+\.service)$@) {
@@ -761,6 +781,7 @@ if(defined($opt_l)) {
 		}
 
 		# No perfect hit - call any rc scripts instead.
+                print STDERR "$LOGPREF #$pid running $hook no perfect hit found $found pids $#nopids\n" if($nrconf{verbosity} > 1);
 		if(!$found && $#nopids > -1) {
 		    foreach my $rc (@nopids) {
 			if($is_systemd && exists($restart{"$rc.service"})) {
@@ -1265,6 +1286,25 @@ if(defined($opt_l) && !$uid) {
 	    }
 	}
     }
+
+	## GUESTS
+	$ui->vspace();
+	if (! @guests) {
+		$ui->notice(__ 'No VM guests are running outdated binaries.') unless($opt_b || $opt_m eq 'e');
+	}
+	else {
+		if($opt_m eq 'e') {
+			push(@easy_hints, __ 'outdated VM guests');
+		}
+		else {
+			unless($opt_p || $opt_b) {
+				$ui->notice(__ 'VM guests running outdated binaries:');
+				foreach ( @guests ) {
+				$ui->notice(__ " $_");
+				}
+			}
+		}
+	}
 }
 
 # easy mode: print hint on outdated stuff

--- a/needrestart
+++ b/needrestart
@@ -781,7 +781,7 @@ if(defined($opt_l)) {
 		}
 
 		# No perfect hit - call any rc scripts instead.
-                print STDERR "$LOGPREF #$pid running $hook no perfect hit found $found pids $#nopids\n" if($nrconf{verbosity} > 1);
+		print STDERR "$LOGPREF #$pid running $hook no perfect hit found $found pids $#nopids\n" if($nrconf{verbosity} > 1);
 		if(!$found && $#nopids > -1) {
 		    foreach my $rc (@nopids) {
 			if($is_systemd && exists($restart{"$rc.service"})) {


### PR DESCRIPTION
Hi,
Needrestart is awesome in detecting long running services or user sessions that are still running with old binaries. But there is another common kind of long-running process - VM Guests.

On one hand this branch adds a bit of protection by greylisting common virtualization services which restart would break running guests.

On the other hand it adds detection and reporting of outdated VMs.
Here an example of a system running a KVM guest in libvirt:

```
# virsh list
 Id   Name          State
-----------------------------
 4    i-testguest   running
```

And on package (re)install with a depending library `libspice-server1` we see the detection and reporting in action:

```
root@i-kvm:~# sudo apt install --reinstall libspice-server1 libvirt0
...
Setting up libspice-server1:amd64 (0.14.3-2ubuntu3) ...
Setting up libvirt0:amd64 (7.4.0-0ubuntu1~impishppa9) ...
Processing triggers for libc-bin (2.33-0ubuntu7) ...
Scanning processes...                                                                                                                                                                          
Scanning candidates...                                                                                                                                                                         

Restarting services...
Service restarts being deferred:
 systemctl restart libvirtd.service

No containers need to be restarted.

No user sessions are running outdated binaries.

VM guests running outdated binaries:
 VM 'i-testguest' with pid 30693
```

The same in verbose/debug mode:

```
root@i-kvm:~# needrestart -v -l
[main] eval /etc/needrestart/needrestart.conf
[main] eval /etc/needrestart/conf.d/virtlogd.conf
[main] needrestart v3.5
[main] running in root mode
[Core] Using UI 'NeedRestart::UI::stdio'...
[main] systemd detected
[main] container detected
[Core] #194 is a NeedRestart::Interp::Python
[Python] #194: source=/usr/bin/networkd-dispatcher
[Core] #241 is a NeedRestart::Interp::Python
[Python] #241: source=/usr/share/unattended-upgrades/unattended-upgrade-shutdown
[main] #24611 uses deleted /usr/lib/x86_64-linux-gnu/libvirt-qemu.so.0.7004.0
[main] #24611 is not a child
[main] #25779 uses deleted /usr/lib/x86_64-linux-gnu/libvirt.so.0.7004.0
[main] #25779 is not a child
[main] #30693 uses deleted /usr/lib/x86_64-linux-gnu/libspice-server.so.1.14.0
[main] #30693 is not a child
[main] #24611 exe => /usr/sbin/libvirtd
[main] #24611 is libvirtd.service
[main] #25779 exe => /usr/sbin/virtlogd
[main] #25779 is virtlogd.service
[main] #30693 exe => /usr/bin/qemu-system-x86_64
[main] #30693 detected as VM guest 'i-testguest' in group '/machine.slice/machine-qemu\x2d4\x2di\x2dtestguest.scope'
[main] virtlogd.service is blacklisted -> ignored
[main] inside container, skipping kernel checks
[main] inside container or vm, skipping microcode checks

Restarting services...
Services to be restarted:
Restart «libvirtd.service»? [yNas?] 
Service restarts being deferred:
 systemctl restart libvirtd.service

No containers need to be restarted.

No user sessions are running outdated binaries.

VM guests running outdated binaries:
 VM 'i-testguest' with pid 30693
```

And in easy mode we get:
`# needrestart -l -m e` => "This system runs outdated binaries and outdated VM guests - you should consider rebooting! "

Right now this only detects the "common" way of a libvirt/qemu setup for guests.
We could move it out of the session checks and try to parse ANY qemu processes if you prefer that.

Furthermore I had no idea what nagios would need/expect and no way to test it so this feature has no nagios support for now.

Please consider this overall as an RFC as I'd need your preference (do we want all qemu processes) and guidance (nagios).
Once discussions happened and this becomes more polished and tested we can un-tag the RFC label and hopefully consider it for inclusion.