### PR TITLE
fix 'uninitialized value $ucode_vars{"AVAIL"}' from AMD ucode

### DIFF
--- a/perl/lib/NeedRestart/uCode/AMD.pm
+++ b/perl/lib/NeedRestart/uCode/AMD.pm
@@ -186,23 +186,26 @@ sub nr_ucode_check_real {
         my $prid = $_ucodes->{cpuid}->{$cpuid};
         if ( exists( $_ucodes->{prid}->{$prid} ) ) {
             $vars{AVAIL} = sprintf( "0x%08x", $_ucodes->{prid}->{$prid} ),
-
-              print STDERR "$LOGPREF #$info->{processor} found ucode $vars{AVAIL}\n" if ($debug);
-            if ( $_ucodes->{prid}->{$prid} > $ucode ) {
-                return ( NRM_OBSOLETE, %vars );
-            }
-        }
-        else {
-            print STDERR "$LOGPREF #$info->{processor} no ucode updates available\n" if ($debug);
-        }
-        return ( NRM_CURRENT, %vars );
-    }
-    else {
-        print STDERR "$LOGPREF #$info->{processor} no ucode updates available\n" if ($debug);
-        return ( NRM_CURRENT, %vars );
+		print STDERR "$LOGPREF #$info->{processor} found ucode $vars{AVAIL}\n" if ($debug);
+	}
     }
 
-    return ( NRM_UNKNOWN, %vars );
+    unless ( exists( $vars{CURRENT} ) && exists( $vars{AVAIL} ) ) {
+        print STDERR
+          "$LOGPREF #$info->{processor} did not get current microcode version\n"
+          if ( $debug && !exists( $vars{CURRENT} ) );
+        print STDERR
+"$LOGPREF #$info->{processor} did not get available microcode version\n"
+          if ( $debug && !exists( $vars{AVAIL} ) );
+
+        return ( NRM_UNKNOWN, %vars );
+    }
+
+    if ( hex( $vars{CURRENT} ) >= hex( $vars{AVAIL} ) ) {
+        return ( NRM_CURRENT, %vars );
+    }
+
+    return ( NRM_OBSOLETE, %vars );
 }
 
 1;

--- a/perl/lib/NeedRestart/uCode/AMD.pm
+++ b/perl/lib/NeedRestart/uCode/AMD.pm
@@ -85,6 +85,9 @@ sub _scan_ucodes {
 
             if ( $pkg_cpuid > 0 ) {
                 $_ucodes->{cpuid}->{$pkg_cpuid} = $pkg_prid;
+		printf STDERR
+		    "$LOGPREF cpuid 0x%08x: found processor id 0x%08x\n", $pkg_cpuid, $pkg_prid
+		    if ($debug);
             }
         }
 
@@ -99,6 +102,9 @@ sub _scan_ucodes {
             ) = unpack( 'VVvCCVVVv', $buf );
 
             $_ucodes->{prid}->{$pat_prid} = $pat_pid;
+	    printf STDERR
+		"$LOGPREF processor id 0x%08x: available ucode 0x%08x\n", $pat_prid, $pat_pid
+		if ($debug);
         }
     }
 }

--- a/perl/lib/NeedRestart/uCode/AMD.pm
+++ b/perl/lib/NeedRestart/uCode/AMD.pm
@@ -170,7 +170,7 @@ sub nr_ucode_check_real {
     printf( STDERR "$LOGPREF #$info->{processor} running ucode 0x%08x\n", $ucode ) if ($debug);
 
     unless ( defined($_ucodes) ) {
-        _scan_ucodes();
+        _scan_ucodes( $debug );
     }
 
     my %vars = ( CURRENT => sprintf( "0x%08x", $ucode ), );

--- a/perl/lib/NeedRestart/uCode/AMD.pm
+++ b/perl/lib/NeedRestart/uCode/AMD.pm
@@ -190,22 +190,7 @@ sub nr_ucode_check_real {
 	}
     }
 
-    unless ( exists( $vars{CURRENT} ) && exists( $vars{AVAIL} ) ) {
-        print STDERR
-          "$LOGPREF #$info->{processor} did not get current microcode version\n"
-          if ( $debug && !exists( $vars{CURRENT} ) );
-        print STDERR
-"$LOGPREF #$info->{processor} did not get available microcode version\n"
-          if ( $debug && !exists( $vars{AVAIL} ) );
-
-        return ( NRM_UNKNOWN, %vars );
-    }
-
-    if ( hex( $vars{CURRENT} ) >= hex( $vars{AVAIL} ) ) {
-        return ( NRM_CURRENT, %vars );
-    }
-
-    return ( NRM_OBSOLETE, %vars );
+    return ( $info->{processor}, %vars );
 }
 
 1;

--- a/perl/lib/NeedRestart/uCode/Intel.pm
+++ b/perl/lib/NeedRestart/uCode/Intel.pm
@@ -83,22 +83,7 @@ sub nr_ucode_check_real {
     }
     $vars{AVAIL} = $_avail if ( defined($_avail) );
 
-    unless ( exists( $vars{CURRENT} ) && exists( $vars{AVAIL} ) ) {
-        print STDERR
-          "$LOGPREF #$info->{processor} did not get current microcode version\n"
-          if ( $debug && !exists( $vars{CURRENT} ) );
-        print STDERR
-"$LOGPREF #$info->{processor} did not get available microcode version\n"
-          if ( $debug && !exists( $vars{AVAIL} ) );
-
-        return ( NRM_UNKNOWN, %vars );
-    }
-
-    if ( hex( $vars{CURRENT} ) >= hex( $vars{AVAIL} ) ) {
-        return ( NRM_CURRENT, %vars );
-    }
-
-    return ( NRM_OBSOLETE, %vars );
+    return ( $info->{processor}, %vars );
 }
 
 1;


### PR DESCRIPTION
This should fix the warning `uninitialized value $ucode_vars{"AVAIL"}` when no microcode is available for an AMD CPU (issue #191).
I have fixed this by adopting the logic for Intel CPUs.

This means that the case _we know the microcode inside the CPU but we don't have any firmware files to see if it is current or not_ now maps to `NRM_UNKNOWN` (like the Intel code did in that case) instead of `NRM_CURRENT` (which was exactly the source of the bug: if we are current we need to know an `AVAIL` version, but we didn't).

Unfortunately, I have no system to really test this on: all my current CPUs (Intel as well as AMD) have no microcode at all available for them.