### PR TITLE
optionally allow a tolerance when checking script files

### DIFF
--- a/man/needrestart.1
+++ b/man/needrestart.1
@@ -52,6 +52,9 @@ nagios plugin mode: makes output and exit codes nagios compatible
 \fB\-f\fR <fe>
 override debconf(7) frontend, sets the DEBIAN_FRONTEND environment variable to <fe>
 .TP
+\fB\-t\fR <seconds>
+When checking running interpreter processes, allow process start times that are close to timestamps of files the interpreter uses, within this tolerance (default 2). The default value of 2 seconds is best for checks of Linux hosts, on which system limitations prevent more accurate measurements of process start times. Values higher than 0 should prevent false positives yet may in extreme cases cause false negatives; values higher than 2 should not be necessary.
+.TP
 \fB\-u\fR <ui>
 use preferred UI package (-u ? shows available packages)
 .PP

--- a/needrestart
+++ b/needrestart
@@ -92,6 +92,7 @@ Usage:
     -b		enable batch mode
     -p          enable nagios plugin mode
     -f <fe>	override debconf frontend (DEBIAN_FRONTEND, debconf(7))
+    -t <seconds> tolerate interpreter process start times within this value
     -u <ui>     use preferred UI package (-u ? shows available packages)
 
   By using the following options only the specified checks are performed:
@@ -157,6 +158,7 @@ our %nrconf = (
     containers => 1,
     },
     has_pam_systemd => 1,
+    tolerance => 2,
 );
 
 # backup ARGV (required for Debconf)
@@ -173,9 +175,10 @@ our $opt_k;
 our $opt_l;
 our $opt_p;
 our $opt_q;
+our $opt_t;
 our $opt_u;
 our $opt_w;
-unless(getopts('c:vr:nm:bf:klpqu:w')) {
+unless(getopts('c:vr:nm:bf:klpqt:u:w')) {
     HELP_MESSAGE;
     exit 1;
 }
@@ -224,6 +227,7 @@ $opt_r = 'l' if(!$is_tty && $opt_r eq 'i');
 $opt_m = $nrconf{ui_mode} unless(defined($opt_m));
 die "ERROR: Unknown UI mode '$opt_m'!\n" unless($opt_m =~ /^(e|a)$/);
 $opt_r = 'l' if($opt_m eq 'e');
+$opt_t = $nrconf{tolerance} unless(defined($opt_t));
 
 $nrconf{defno}++ if($opt_n);
 $opt_b++ if($opt_p);
@@ -564,11 +568,11 @@ if(defined($opt_l)) {
 	}
 
 	unless($restart || !$nrconf{interpscan}) {
-	    $restart++ if(needrestart_interp_check($nrconf{verbosity} > 1, $pid, $exe, $nrconf{blacklist_interp}));
+	    $restart++ if(needrestart_interp_check($nrconf{verbosity} > 1, $pid, $exe, $nrconf{blacklist_interp}, $opt_t));
 	}
 
 	# handle containers (LXC, docker, etc.)
-	next if($restart && needrestart_cont_check($nrconf{verbosity} > 1, $pid, $exe));
+	next if($restart && needrestart_cont_check($nrconf{verbosity} > 1, $pid, $exe, $opt_t));
 
 	# restart needed?
 	next unless($restart);

--- a/perl/lib/NeedRestart.pm
+++ b/perl/lib/NeedRestart.pm
@@ -155,11 +155,12 @@ sub needrestart_interp_init($) {
     }
 }
 
-sub needrestart_interp_check($$$$) {
+sub needrestart_interp_check($$$$$) {
     my $debug = shift;
     my $pid = shift;
     my $bin = shift;
     my $blacklist = shift;
+    my $tolerance = shift;
 
     needrestart_interp_init($debug) unless(%Interps);
 
@@ -176,7 +177,7 @@ sub needrestart_interp_check($$$$) {
 		delete($files{$path});
 	    }
 
-	    if(grep {!defined($_) || $_ > $ps->start} values %files) {
+	    if(grep {!defined($_) || $_ > $ps->start + $tolerance} values %files) {
 		if($debug) {
 		    print STDERR "$LOGPREF #$pid uses obsolete script file(s):";
 		    print STDERR join("\n$LOGPREF #$pid  ", '', map {(!defined($files{$_}) || $files{$_} > $ps->start ? $_ : ())} keys %files);


### PR DESCRIPTION
This addresses:
https://github.com/liske/needrestart/issues/228
...without being a complete "fix", since that does not seem to be
possible.

Further details are in the bug report above, but in brief, Linux can
only report process start time with a precision of 1.1 seconds, and that
gets rounded off, thus false positives are quite possible for processes
that start immediately after their files are created.

Since this can allow some false negatives, allow the user to decide.
The default tolerance of 0 is no change from the previous behavior of
having no tolerance.