### PR TITLE
Fix docker detection with cgroups v2

### DIFF
--- a/perl/lib/NeedRestart/CONT/docker.pm
+++ b/perl/lib/NeedRestart/CONT/docker.pm
@@ -67,9 +67,9 @@ sub check {
     }
 
     # look for docker cgroups
-    return 0 unless($cg =~ /^\d+:[^:]+:\/system.slice\/docker-(.+)\.scope$/m ||
-                    $cg =~ /^\d+:[^:]+:\/system.slice\/docker\.service$/m ||
-                    $cg =~ /^\d+:[^:]+:\/docker\/([\da-f]+)$/m);
+    return 0 unless($cg =~ /^\d+:[^:]*:\/system.slice\/docker-(.+)\.scope$/m ||
+                    $cg =~ /^\d+:[^:]*:\/system.slice\/docker\.service$/m ||
+                    $cg =~ /^\d+:[^:]*:\/docker\/([\da-f]+)$/m);
 
     print STDERR "$LOGPREF #$pid is part of docker container '$1' and will be ignored\n" if($self->{debug});
 


### PR DESCRIPTION
On Debian bullseye there will not always be a string after the first colon.

Example:

    0::/system.slice/docker-xxx.scope

It might make sense to change this for LXC as well...