### PR TITLE
Fix LXC/LXD and machined detection for cgroups v2

### DIFF
--- a/perl/lib/NeedRestart/CONT/LXC.pm
+++ b/perl/lib/NeedRestart/CONT/LXC.pm
@@ -81,7 +81,7 @@ sub check {
     }
 
     # look for LXC cgroups
-    return unless($cg =~ /^\d+:[^:]+:\/lxc(?:.payload)?[.\/]([^\/\n]+)($|\/)/m);
+    return unless($cg =~ /^\d+:[^:]*:\/lxc(?:.payload)?[.\/]([^\/\n]+)($|\/)/m);
 
     my $name = $1;
     my $type = ($self->{has_lxd} && -d qq($self->{lxd_container_path}/$name) ? 'LXD' : 'LXC');

--- a/perl/lib/NeedRestart/CONT/machined.pm
+++ b/perl/lib/NeedRestart/CONT/machined.pm
@@ -68,7 +68,7 @@ sub check {
     }
 
     # look for machined cgroups
-    return 0 unless($cg =~ /^\d+:[^:]+:\/machine.slice\/machine-(.+)\.scope$/m);
+    return 0 unless($cg =~ /^\d+:[^:]*:\/machine.slice\/machine-(.+)\.scope$/m);
 
     my $name = $1;
     unless($norestart) {


### PR DESCRIPTION
The second field is always blank in cgroups v2 unlike v1, adjust parsing to
support both cases for LXC/LXD and machined. This is the same fix as previously
made for Docker in #234.

Example: 0::/lxc.payload.focal/system.slice/avahi-daemon.service