### PR TITLE
Correct syntax

### DIFF
--- a/ex/needrestart.conf
+++ b/ex/needrestart.conf
@@ -108,8 +108,8 @@ $nrconf{override_rc} = {
     qr(^xendomains) => 0,
     qr(^lxcfs) => 0,
     qr(^libvirt) => 0,
-    qr(^virtlogd)} = 0,
-    qr(^virtlockd)} = 0,
+    qr(^virtlogd) => 0,
+    qr(^virtlockd) => 0,
     qr(^docker) => 0,
 
     # systemd stuff


### PR DESCRIPTION
```
Error parsing /etc/needrestart/needrestart.conf: Can't modify anonymous hash ({}) in scalar assignment at (eval 12) line 111, near "0,"
Unmatched right curly bracket at (eval 12) line 112, at end of line
syntax error at (eval 12) line 112, near "qr(^virtlockd)}"
Unmatched right curly bracket at (eval 12) line 133, at end of line
```