### PR TITLE
fix and simplify example lsinitrd command

### DIFF
--- a/ex/iucode.sh
+++ b/ex/iucode.sh
@@ -11,6 +11,6 @@
 # exec iucode_tool -l $filter --ignore-broken -tb /lib/firmware/intel-ucode -ta /usr/share/misc/intel-microcode* 2>&1
 # exit $?
 
-# Example (CentOS):
-# lsinitrd -f kernel/x86/microcode/GenuineIntel.bin $(/boot/initramfs-*.img|sort -n|tail -n 1) | iucode_tool -t b -l -
+# Example (RHEL and derivatives):
+# lsinitrd -f kernel/x86/microcode/GenuineIntel.bin | iucode_tool -t b -l -
 # exit $?


### PR DESCRIPTION
The original command prints:
```
[dev: root@dcoreytest02 ~]# lsinitrd -f kernel/x86/microcode/GenuineIntel.bin $(/boot/initramfs-*.img|sort -n|tail -n 1) | iucode_tool -t b -l -
-bash: /boot/initramfs-4.18.0-348.20.1.el8_5.x86_64.img: Permission denied
microcode bundle 1: (stdin)
selected microcodes:
  001/001: sig 0x000906e9, pf_mask 0x2a, 2019-04-01, rev 0x00b4, size 99328
```

Note the error: bash is trying to execute the initramfs file. The output
is correct anyway because lsinitrd automatically defaults to the correct
initramfs file for the running kernel. Thus, there is no need to specify
the file at all.

```
[dev: root@dcoreytest02 ~]# lsinitrd -f kernel/x86/microcode/GenuineIntel.bin | iucode_tool -t b -l -
microcode bundle 1: (stdin)
selected microcodes:
  001/001: sig 0x000906e9, pf_mask 0x2a, 2019-04-01, rev 0x00b4, size 99328
```

This is tested on CentOS 6.10, 7.2, 7.4, 7.8, 7.9, and Alma 8.5.

On CentOS 6.10, this should work (I don't have the other components, but
lsinitrd works).

On CentOS 6.5, lsinitrd does not accept arguments, so neither the old
command nor the new command will work.