### PR TITLE
Prevent shell expansion of $nrconf in example

### DIFF
--- a/README.raspberry.md
+++ b/README.raspberry.md
@@ -14,7 +14,7 @@ is a configuration option in needrestart to filter the kernel image filenames to
 ignore the unused image files. To filter the kernel image on a RPi 2 or RPi 3:
 
 ```shell
-$ cat << EOF > /etc/needrestart/conf.d/kernel.conf
+$ cat << 'EOF' > /etc/needrestart/conf.d/kernel.conf
 # Filter kernel image filenames by regex. This is required on Raspian having
 # multiple kernel image variants installed in parallel.
 $nrconf{kernelfilter} = qr(kernel7\.img);


### PR DESCRIPTION
Use << 'EOF' instead of << EOF to prevent shell expansion of $nrconf.