### PR TITLE
ignore USBGuard

### DIFF
--- a/ex/needrestart.conf
+++ b/ex/needrestart.conf
@@ -103,6 +103,7 @@ $nrconf{override_rc} = {
     qr(^user@\d+\.service) => 0,
 
     # misc
+    qr(^usbguard\.service$) => 0,
     qr(^zfs-fuse) => 0,
     qr(^mythtv-backend) => 0,
     qr(^xendomains) => 0,


### PR DESCRIPTION
When any of USBGuard’s `PresentDevicePolicy`- and `PresentControllerPolicy`- options are set to `apply-policy`, `block` or `reject`, then a restart of `usbguard.service` might cause a previously manually allowed device to no longer be so.
If that’s e.g. a device holding a mounted filesystem, that mount would immediately be interrupted (not in a clean way) and data corruption might occur.

Restarting `usbguard-dbus.service` doesn’t seem to be a problem, though.

Ideally this would be fixed in USBGuard and I’ve filed an issue for that: https://github.com/USBGuard/usbguard/issues/565
Once that would have been implemented, this commit should be reverted.

Signed-off-by: Christoph Anton Mitterer <mail@christoph.anton.mitterer.name>