### PR TITLE
properly detect dhclient

### DIFF
--- a/ex/needrestart.conf
+++ b/ex/needrestart.conf
@@ -54,9 +54,6 @@ $nrconf{blacklist} = [
     # ignore sudo (not a daemon)
     qr(^/usr/bin/sudo(\.dpkg-new)?$),
 
-    # ignore DHCP clients
-    qr(^/sbin/(dhclient|dhcpcd5|pump|udhcpc)(\.dpkg-new)?$),
-
     # ignore apt-get (Debian Bug#784237)
     qr(^/usr/bin/apt-get(\.dpkg-new)?$),
 ];
@@ -89,6 +86,7 @@ $nrconf{override_rc} = {
     qr(^NetworkManager) => 0,
     qr(^ModemManager) => 0,
     qr(^wpa_supplicant) => 0,
+    qr(^ifup) => 0,
     qr(^openvpn) => 0,
     qr(^quagga) => 0,
     qr(^frr) => 0,


### PR DESCRIPTION
We make the call here that dhclient should be *detected*, if not properly restarted. We try to workaround the problem that restarts fail or destroy the network by adding ifupdown to the long list of services that cannot be restarted.

We've been running an equivalent configuration in production at the Tor Project over about 100 Debian machines running Debian buster and bullseye for months without negative issues.

Closes: #225