### PR TITLE
Add greetd to the list of restart exclusions

### DIFF
--- a/ex/needrestart.conf
+++ b/ex/needrestart.conf
@@ -74,6 +74,7 @@ $nrconf{override_rc} = {
 
     # display managers
     qr(^gdm) => 0,
+    qr(^greetd) => 0,
     qr(^kdm) => 0,
     qr(^nodm) => 0,
     qr(^sddm) => 0,


### PR DESCRIPTION
Since it is a display manager, we don't want to restart it because the logged in user would be thrown out.