### PR TITLE
[uCode] fix uninitialized value in logging of processor index

### DIFF
--- a/perl/lib/NeedRestart/uCode.pm
+++ b/perl/lib/NeedRestart/uCode.pm
@@ -148,7 +148,7 @@ sub nr_ucode_check {
             }
             $ui->progress_step;
 
-            my $nstate = compare_ucode_versions( $debug, $processors{processor}, @nvars );
+            my $nstate = compare_ucode_versions( $debug, $pid, @nvars );
             if ( $nstate > $state ) {
                 ( $state, @vars ) = ( $nstate, @nvars );
             }


### PR DESCRIPTION
This got broken in f8c2609f8d5a0e10bd988497b8ea9815a7bb2fa8.

Before that it would have effectively logged `$processors{$pid}->{processor}`, but the `processor` entry is also the key in `%processors`, i.e. equals `$pid`.