### PR TITLE
Fix AMD uCode check in non-debug mode

### DIFF
--- a/perl/lib/NeedRestart/uCode/AMD.pm
+++ b/perl/lib/NeedRestart/uCode/AMD.pm
@@ -185,9 +185,9 @@ sub nr_ucode_check_real {
     if ( exists( $_ucodes->{cpuid}->{$cpuid} ) ) {
         my $prid = $_ucodes->{cpuid}->{$cpuid};
         if ( exists( $_ucodes->{prid}->{$prid} ) ) {
-            $vars{AVAIL} = sprintf( "0x%08x", $_ucodes->{prid}->{$prid} ),
-		print STDERR "$LOGPREF #$info->{processor} found ucode $vars{AVAIL}\n" if ($debug);
-	}
+            $vars{AVAIL} = sprintf( "0x%08x", $_ucodes->{prid}->{$prid} );
+            print STDERR "$LOGPREF #$info->{processor} found ucode $vars{AVAIL}\n" if ($debug);
+        }
     }
 
     return %vars;


### PR DESCRIPTION
Commit 149e546 introduced a logic error, so that the available microcode version was only returned in debug mode due to the comma on the previous line and the postfixed `if ($debug)`.