### PR TITLE
Use a persistent cache file of perl scanning results.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -41,6 +41,8 @@ install: all
 	
 	mkdir -p "$(DESTDIR)$(LOCALEDIR)"
 	cp -r po/.build/* "$(DESTDIR)$(LOCALEDIR)/"
+	
+	mkdir -p "$(DESTDIR)/var/cache/needrestart"
 
 clean:
 	[ ! -f perl/Makefile ] || ( cd perl && $(MAKE) realclean )

--- a/ex/needrestart.conf
+++ b/ex/needrestart.conf
@@ -141,6 +141,9 @@ $nrconf{override_cont} = {
 # Disable interpreter scanners.
 #$nrconf{interpscan} = 0;
 
+# Use a persistent cache file of perl scanning results
+#$nrconf{perlcache} = "/var/cache/needrestart/perl_scandeps_cache";
+
 # Ignore script files matching these regexs:
 $nrconf{blacklist_interp} = [
     # ignore temporary files

--- a/needrestart
+++ b/needrestart
@@ -155,6 +155,7 @@ our %nrconf = (
     override_cont => {},
     skip_mapfiles => -1,
     interpscan => 1,
+    perlcache => undef,
     kernelhints => 1,
     kernelfilter => qr(.),
     ucodehints => 1,
@@ -240,6 +241,12 @@ $opt_t = $nrconf{tolerance} unless(defined($opt_t));
 
 $nrconf{defno}++ if($opt_n);
 $opt_b++ if($opt_p);
+
+needrestart_interp_configure({
+    perl => {
+        cache_file => $nrconf{perlcache},
+    },
+});
 
 # print version in verbose mode
 print STDERR "$LOGPREF needrestart v$NeedRestart::VERSION\n" if($nrconf{verbosity} > 1);

--- a/perl/lib/NeedRestart.pm
+++ b/perl/lib/NeedRestart.pm
@@ -49,6 +49,7 @@ our @EXPORT = qw(
 
     needrestart_ui
     needrestart_ui_list
+    needrestart_interp_configure
     needrestart_interp_check
     needrestart_interp_source
     needrestart_cont_check
@@ -135,13 +136,20 @@ sub needrestart_ui_list {
 
 
 my %Interps;
+my $InterpConf;
 my %InterpCache;
 my $idebug;
 
-sub needrestart_interp_register($) {
-    my $pkg = shift;
+sub needrestart_interp_configure($) {
+    my $conf = shift;
+    $InterpConf = $conf;
+}
 
-    $Interps{$pkg} = new $pkg($idebug);
+sub needrestart_interp_register($$) {
+    my $pkg = shift;
+    my $confkey = shift;
+
+    $Interps{$pkg} = new $pkg($idebug, $InterpConf->{$confkey});
 }
 
 sub needrestart_interp_init($) {

--- a/perl/lib/NeedRestart/Interp.pm
+++ b/perl/lib/NeedRestart/Interp.pm
@@ -30,9 +30,11 @@ use warnings;
 sub new {
     my $class = shift;
     my $debug = shift;
+    my $conf = shift;
 
     return bless {
 	debug => $debug,
+        conf => $conf,
     }, $class;
 }
 

--- a/perl/lib/NeedRestart/Interp/Java.pm
+++ b/perl/lib/NeedRestart/Interp/Java.pm
@@ -33,7 +33,7 @@ use NeedRestart::Utils;
 
 my $LOGPREF = '[Java]';
 
-needrestart_interp_register(__PACKAGE__);
+needrestart_interp_register(__PACKAGE__, "java");
 
 sub isa {
     my $self = shift;

--- a/perl/lib/NeedRestart/Interp/Perl.pm
+++ b/perl/lib/NeedRestart/Interp/Perl.pm
@@ -36,7 +36,7 @@ use Module::ScanDeps;
 
 my $LOGPREF = '[Perl]';
 
-needrestart_interp_register(__PACKAGE__);
+needrestart_interp_register(__PACKAGE__, "perl");
 
 sub isa {
     my $self = shift;
@@ -178,6 +178,7 @@ sub files {
 	$href = scan_deps(
 	    files => [$src],
 	    recurse => 1,
+            cache_file => $self->{conf}->{cache_file},
 	    );
     }
 

--- a/perl/lib/NeedRestart/Interp/Python.pm
+++ b/perl/lib/NeedRestart/Interp/Python.pm
@@ -35,7 +35,7 @@ use NeedRestart::Utils;
 
 my $LOGPREF = '[Python]';
 
-needrestart_interp_register(__PACKAGE__);
+needrestart_interp_register(__PACKAGE__, "python");
 
 sub isa {
     my $self = shift;

--- a/perl/lib/NeedRestart/Interp/Ruby.pm
+++ b/perl/lib/NeedRestart/Interp/Ruby.pm
@@ -35,7 +35,7 @@ use NeedRestart::Utils;
 
 my $LOGPREF = '[Ruby]';
 
-needrestart_interp_register(__PACKAGE__);
+needrestart_interp_register(__PACKAGE__, "ruby");
 
 sub isa {
     my $self = shift;


### PR DESCRIPTION
The new configuration option "perlcache" enables caching and sets the path to the cache file managed by Module::ScanDeps.

Fixes #279