### PR TITLE
Improvement to CPU Vendor tests

### DIFF
--- a/perl/lib/NeedRestart/uCode/AMD.pm
+++ b/perl/lib/NeedRestart/uCode/AMD.pm
@@ -116,7 +116,7 @@ sub nr_ucode_check_real {
 
     # check for AMD cpu
     unless ( defined( $info->{vendor_id} )
-        && $info->{vendor_id} eq 'AuthenticAMD' )
+        && $info->{vendor_id} =~ /amd/i )
     {
         die "$LOGPREF #$info->{processor} cpu vendor id mismatch\n";
     }

--- a/perl/lib/NeedRestart/uCode/AMD.pm
+++ b/perl/lib/NeedRestart/uCode/AMD.pm
@@ -116,7 +116,7 @@ sub nr_ucode_check_real {
 
     # check for AMD cpu
     unless ( defined( $info->{vendor_id} )
-        && $info->{vendor_id} =~ /amd/i )
+        && $info->{vendor_id} eq 'AuthenticAMD' )
     {
         die "$LOGPREF #$info->{processor} cpu vendor id mismatch\n";
     }

--- a/perl/lib/NeedRestart/uCode/Intel.pm
+++ b/perl/lib/NeedRestart/uCode/Intel.pm
@@ -52,6 +52,13 @@ sub nr_ucode_check_real {
     my $info  = shift;
     my %vars;
 
+    # check for Intel cpu
+    unless ( defined( $info->{vendor_id} )
+        && $info->{vendor_id} =~ /intel/i )
+    {
+        die "$LOGPREF #$info->{processor} cpu vendor id mismatch\n";
+    }
+
     # get current microcode revision
     if ( defined( $info->{microcode} ) ) {
         $vars{CURRENT} = sprintf( "0x%04x", hex( $info->{microcode} ) );

--- a/perl/lib/NeedRestart/uCode/Intel.pm
+++ b/perl/lib/NeedRestart/uCode/Intel.pm
@@ -54,7 +54,7 @@ sub nr_ucode_check_real {
 
     # check for Intel cpu
     unless ( defined( $info->{vendor_id} )
-        && $info->{vendor_id} =~ /intel/i )
+        && $info->{vendor_id} eq 'GenuineIntel' )
     {
         die "$LOGPREF #$info->{processor} cpu vendor id mismatch\n";
     }


### PR DESCRIPTION
In response to #274, this should prevent Intel uCode from being attempted on AMD. It has not been tested on Intel CPUs however and should be before merging.

The existing check from the AMD.pm was implemented for the Intel.pm in the same style. Both were updated to use a case-insensitive regex.