### PR TITLE
Fix AMD Microcode Check

### DIFF
--- a/perl/lib/NeedRestart/uCode.pm
+++ b/perl/lib/NeedRestart/uCode.pm
@@ -52,6 +52,8 @@ my $LOGPREF = '[ucode]';
 sub compare_ucode_versions {
     my ($debug, $processor, %vars) = @_;
 
+    print STDERR "$LOGPREF DEBUG: ", join(", ", map { "$_ => $vars{$_}" } keys %vars), "\n", if ($debug);
+
     unless ( exists( $vars{CURRENT} ) && exists( $vars{AVAIL} ) ) {
         print STDERR
 	    "$LOGPREF #$processor did not get current microcode version\n"

--- a/perl/lib/NeedRestart/uCode/AMD.pm
+++ b/perl/lib/NeedRestart/uCode/AMD.pm
@@ -189,6 +189,10 @@ sub nr_ucode_check_real {
 		print STDERR "$LOGPREF #$info->{processor} found ucode $vars{AVAIL}\n" if ($debug);
 	}
     }
+    elsif (keys %{ $_ucodes->{cpuid} } > 0) {
+        printf( STDERR "$LOGPREF Found microcode, but no matching cpuid for #$info->{processor} 0x%08x\n", $cpuid ) if ($debug);
+        $vars{AVAIL} = 0;
+    }
 
     return %vars;
 }


### PR DESCRIPTION
As discussed in #249, the default behavior for AMD was changed with pull request #226 and as a result, CPUs that do not have microcode patches (because they're up to date) were leading to NRM_UNKNOWN resulting in "Failed to check for processor microcode upgrades." which is inaccurate.

This sets the $vars{AVAIL} to 0 if there are microcode patches to scan and none apply. While this doesn't guarantee microcode is up to date or from a valid source, it restores the previous behavior while accounting for the edge case presented in the previous pull request.