### PR TITLE
mark unavailable firmware as CURRENT

### DIFF
--- a/perl/lib/NeedRestart/uCode.pm
+++ b/perl/lib/NeedRestart/uCode.pm
@@ -52,13 +52,26 @@ my $LOGPREF = '[ucode]';
 sub compare_ucode_versions {
     my ($debug, $processor, %vars) = @_;
 
-    unless ( exists( $vars{CURRENT} ) && exists( $vars{AVAIL} ) ) {
-        print STDERR
-	    "$LOGPREF #$processor did not get current microcode version\n"
-	    if ( $debug && !exists( $vars{CURRENT} ) );
+    # if no firmware is available for the current CPU, that's
+    # considered up to date. the rationale here is that if we warn on
+    # this, we're actually going to warn for certain new CPUs that
+    # have an up-to-date, built-in firmware without any update. that,
+    # in turn, creates alert fatigue and makes operators more likely
+    # to ignore warnings.
+    unless ( exists( $vars{AVAIL} ) ) {
         print STDERR
 	    "$LOGPREF #$processor did not get available microcode version\n"
-	    if ( $debug && !exists( $vars{AVAIL} ) );
+	    if ( $debug );
+        return NRM_CURRENT;
+    }
+    # from here on, there is a microcode file available
+    #
+    # if we can't find a microcode firmware for the current CPU,
+    # *that* is a problem.
+    unless ( exists( $vars{CURRENT} )  ) {
+        print STDERR
+            "$LOGPREF #$processor did not get current microcode version\n"
+            if ( $debug);
 
         return NRM_UNKNOWN;
     }


### PR DESCRIPTION
This changes the policy of reporting missing firmware updates as "UNKNOWN". Now, if there's no available firmware, we report "current". That fixes needrestart on platforms that do not have firmware support (#220) or platforms that *are* supported but for which a CPU is to new to have an updated firmware available (#149).

It does *not* create a new "unavailable" status (#274) as this maps poorly in Nagios reporting, but that is an option that was considered here as well.

Closes: #149
Closes: #274
Closes: #220

This PR and #288 should fix all pending AMD firmware issues, and supersede #285 and possibly make #284 irrelevant as well.