### PR TITLE
Better `systemd --user` integration

### DIFF
--- a/ex/restart.d/systemd-user
+++ b/ex/restart.d/systemd-user
@@ -1,0 +1,24 @@
+#!/bin/sh
+
+# needrestart - Restart daemons after library updates.
+#
+# Restarting `systemd --user` by signaling it with SIGRTMIN+25.
+# (documented in systemd(1) as equivalent to `systemctl --user daemon-reexec`,
+#  but easier to do outside of a user session)
+#
+
+# enable xtrace if we should be verbose
+if [ "$NR_VERBOSE" = '1' ]; then
+    set -x
+fi
+
+# also possible to use `--value` (systemd 230+)
+systemctl show --state=active --property=MainPID 'user@*.service' | while IFS='=' read -r _ pid; do
+    # skip empty lines produced by `systemctl show` if the property
+    # did not exist or could not be queried
+    if [ -z "$pid" ]; then continue; fi
+
+    # also possible as: `systemctl kill --kill-whom=main --signal='SIGRTMIN+25' "$unit"` (systemd 252+)
+    # also possible as: `systemctl -M "$uid@.host" --user daemon-reexec` (systemd 248+)
+    command kill -SIGRTMIN+25 "$pid"
+done

--- a/needrestart
+++ b/needrestart
@@ -706,59 +706,44 @@ if(defined($opt_l)) {
 		}
 
 		# get unit name from /proc/<pid>/cgroup
-		if(open(HCGROUP, qq(/proc/$pid/cgroup))) {
-		    my ($rc) = map {
-			chomp;
-			my ($id, $type, $value) = split(/:/);
-			if($id != 0 && $type ne q(name=systemd)) {
-			    ();
-			}
-			else {
-			    if($value =~ m@/user-(\d+)\.slice/session-(\d+)\.scope@) {
-				print STDERR "$LOGPREF #$pid part of user session: uid=$1 sess=$2\n" if($nrconf{verbosity} > 1);
-				push(@{ $sessions{$1}->{"session #$2"}->{ $ptable->{$pid}->{fname} } }, $pid);
-				next;
-			    }
-			    if($value =~ m@/user\@(\d+)\.service@) {
-				print STDERR "$LOGPREF #$pid part of user manager service: uid=$1\n" if($nrconf{verbosity} > 1);
-				push(@{ $sessions{$1}->{'user manager service'}->{ $ptable->{$pid}->{fname} } }, $pid);
-				next;
-			    }
-			    if($value =~ m@/machine.slice/machine.qemu(.*).scope@) {
-				for my $cmdlineidx (0 .. $#{$ptable->{$pid}->{cmdline}} ) {
-				    if ( ${$ptable->{$pid}->{cmdline}}[$cmdlineidx] eq "-name") {
-					foreach ( split(/,/, ${$ptable->{$pid}->{cmdline}}[$cmdlineidx+1]) ) {
-					    if ( index($_, "guest=") == 0 ) {
-						my @namearg = split(/=/, $_, 2);
-						if ($#{namearg} == 1) {
-						    print STDERR "$LOGPREF #$pid detected as VM guest '$namearg[1]' in group '$value'\n" if($nrconf{verbosity} > 1);
-						    push(@guests, __x("'{name}' with pid {pid}", name => $namearg[1], pid=>$pid) );
-						}
-						next PIDLOOP;
-					    }
-					}
+		my $cgroup = nr_get_cgroup($pid);
+		if($cgroup =~ m@/user-(\d+)\.slice/session-(\d+)\.scope@) {
+		    print STDERR "$LOGPREF #$pid part of user session: uid=$1 sess=$2\n" if($nrconf{verbosity} > 1);
+		    push(@{ $sessions{$1}->{"session #$2"}->{ $ptable->{$pid}->{fname} } }, $pid);
+		    next;
+		}
+		if($cgroup =~ m@/user\@(\d+)\.service@) {
+		    print STDERR "$LOGPREF #$pid part of user manager service: uid=$1\n" if($nrconf{verbosity} > 1);
+		    push(@{ $sessions{$1}->{'user manager service'}->{ $ptable->{$pid}->{fname} } }, $pid);
+		    next;
+		}
+		if($cgroup =~ m@/machine.slice/machine.qemu(.*).scope@) {
+		    for my $cmdlineidx (0 .. $#{$ptable->{$pid}->{cmdline}} ) {
+			if ( ${$ptable->{$pid}->{cmdline}}[$cmdlineidx] eq "-name") {
+			    foreach ( split(/,/, ${$ptable->{$pid}->{cmdline}}[$cmdlineidx+1]) ) {
+				if ( index($_, "guest=") == 0 ) {
+				    my @namearg = split(/=/, $_, 2);
+				    if ($#{namearg} == 1) {
+					print STDERR "$LOGPREF #$pid detected as VM guest '$namearg[1]' in group '$cgroup'\n" if($nrconf{verbosity} > 1);
+					push(@guests, __x("'{name}' with pid {pid}", name => $namearg[1], pid=>$pid) );
 				    }
+				    next PIDLOOP;
 				}
-				print STDERR "$LOGPREF #$pid detected as VM guest with unknown name in group '$value'\n" if($nrconf{verbosity} > 1);
-				push(@guests, __x("'Unknown VM' with pid {pid}", pid=>$pid) );
-				next;
-			    }
-			    elsif($value =~ m@/([^/]+\.service)$@) {
-				($1);
-			    }
-			    else {
-				print STDERR "$LOGPREF #$pid unexpected cgroup '$value'\n" if($nrconf{verbosity} > 1);
-				();
 			    }
 			}
-		    } <HCGROUP>;
-		    close(HCGROUP);
-
-		    if($rc) {
-			print STDERR "$LOGPREF #$pid is $rc\n" if($nrconf{verbosity} > 1);
-			$restart{$rc}++;
-			next;
 		    }
+		    print STDERR "$LOGPREF #$pid detected as VM guest with unknown name in group '$cgroup'\n" if($nrconf{verbosity} > 1);
+		    push(@guests, __x("'Unknown VM' with pid {pid}", pid=>$pid) );
+		    next;
+		}
+		elsif($cgroup =~ m@/([^/]+\.service)$@) {
+		    my $unit = $1;
+		    print STDERR "$LOGPREF #$pid is $unit\n" if($nrconf{verbosity} > 1);
+		    $restart{$unit}++;
+		    next;
+		}
+		elsif($cgroup) {
+		    print STDERR "$LOGPREF #$pid unexpected cgroup '$cgroup'\n" if($nrconf{verbosity} > 1);
 		}
 
 		# did not get the unit name, yet - try systemctl status

--- a/needrestart
+++ b/needrestart
@@ -698,15 +698,22 @@ if(defined($opt_l)) {
 	    next if(grep { $exe =~ /$_/; } @{$nrconf{blacklist}});
 
 	    if($is_systemd) {
+		# get unit name from /proc/<pid>/cgroup
+		my $cgroup = nr_get_cgroup($pid);
 		# systemd manager
-		if($pid == 1 && $exe =~ m@^(/usr)?/lib/systemd/systemd@) {
+		if($cgroup =~ m@^/init\.scope$@ || ($pid == 1 && $exe =~ m@^(/usr)?/lib/systemd/systemd@)) {
 		    print STDERR "$LOGPREF #$pid is systemd manager\n" if($nrconf{verbosity} > 1);
 		    $restart{q(systemd-manager)}++;
 		    next;
 		}
+		# `systemd --user` manager
+		if($cgroup =~ m@/user\@(\d+)\.service/init\.scope$@ && $ptable->{$pid}->{fname} ne "(sd-pam)") {
+		    print STDERR "$LOGPREF #$pid is user systemd manager: uid=$1\n" if($nrconf{verbosity} > 1);
+		    # TODO: restart specific `systemd --user` instance?
+		    $restart{q(systemd-user)}++;
+		    next;
+		}
 
-		# get unit name from /proc/<pid>/cgroup
-		my $cgroup = nr_get_cgroup($pid);
 		if($cgroup =~ m@/user-(\d+)\.slice/session-(\d+)\.scope@) {
 		    print STDERR "$LOGPREF #$pid part of user session: uid=$1 sess=$2\n" if($nrconf{verbosity} > 1);
 		    push(@{ $sessions{$1}->{"session #$2"}->{ $ptable->{$pid}->{fname} } }, $pid);

--- a/needrestart
+++ b/needrestart
@@ -724,20 +724,20 @@ if(defined($opt_l)) {
 				push(@{ $sessions{$1}->{'user manager service'}->{ $ptable->{$pid}->{fname} } }, $pid);
 				next;
 			    }
-				if($value =~ m@/machine.slice/machine.qemu(.*).scope@) {
+			    if($value =~ m@/machine.slice/machine.qemu(.*).scope@) {
 				for my $cmdlineidx (0 .. $#{$ptable->{$pid}->{cmdline}} ) {
-					if ( ${$ptable->{$pid}->{cmdline}}[$cmdlineidx] eq "-name") {
-						foreach ( split(/,/, ${$ptable->{$pid}->{cmdline}}[$cmdlineidx+1]) ) {
-							if ( index($_, "guest=") == 0 ) {
-								my @namearg = split(/=/, $_, 2);
-								if ($#{namearg} == 1) {
-									print STDERR "$LOGPREF #$pid detected as VM guest '$namearg[1]' in group '$value'\n" if($nrconf{verbosity} > 1);
-									push(@guests, __x("'{name}' with pid {pid}", name => $namearg[1], pid=>$pid) );
-								}
-								next PIDLOOP;
-							}
+				    if ( ${$ptable->{$pid}->{cmdline}}[$cmdlineidx] eq "-name") {
+					foreach ( split(/,/, ${$ptable->{$pid}->{cmdline}}[$cmdlineidx+1]) ) {
+					    if ( index($_, "guest=") == 0 ) {
+						my @namearg = split(/=/, $_, 2);
+						if ($#{namearg} == 1) {
+						    print STDERR "$LOGPREF #$pid detected as VM guest '$namearg[1]' in group '$value'\n" if($nrconf{verbosity} > 1);
+						    push(@guests, __x("'{name}' with pid {pid}", name => $namearg[1], pid=>$pid) );
 						}
+						next PIDLOOP;
+					    }
 					}
+				    }
 				}
 				print STDERR "$LOGPREF #$pid detected as VM guest with unknown name in group '$value'\n" if($nrconf{verbosity} > 1);
 				push(@guests, __x("'Unknown VM' with pid {pid}", pid=>$pid) );

--- a/needrestart
+++ b/needrestart
@@ -654,7 +654,7 @@ if(defined($opt_l)) {
 
 	# find parent process
 	my $ppid = $ptable->{$pid}->{ppid};
-	if($ppid != $pid && $ppid > 1 && !$uid) {
+	if($ppid != $pid && $ppid > 1) {
 	    print STDERR "$LOGPREF #$pid is a child of #$ppid\n" if($nrconf{verbosity} > 1);
 
 	    if($uid && $ptable->{$ppid}->{uid} != $uid) {

--- a/needrestart
+++ b/needrestart
@@ -654,7 +654,7 @@ if(defined($opt_l)) {
 
 	# find parent process
 	my $ppid = $ptable->{$pid}->{ppid};
-	if($ppid != $pid && $ppid > 1) {
+	if($ppid != $pid && $ppid > 1 && !($is_systemd && nr_is_systemd_manager($ppid))) {
 	    print STDERR "$LOGPREF #$pid is a child of #$ppid\n" if($nrconf{verbosity} > 1);
 
 	    if($uid && $ptable->{$ppid}->{uid} != $uid) {

--- a/needrestart
+++ b/needrestart
@@ -719,9 +719,14 @@ if(defined($opt_l)) {
 		    push(@{ $sessions{$1}->{"session #$2"}->{ $ptable->{$pid}->{fname} } }, $pid);
 		    next;
 		}
+		if($cgroup =~ m@/user\@(\d+)\.service(/.+\.slice)*/([^/]+\.service)$@) {
+		    print STDERR "$LOGPREF #$pid part of user service: uid=$1 unit=$3\n" if($nrconf{verbosity} > 1);
+		    push(@{ $sessions{$1}->{'user service'}->{ $3 } }, $pid);
+		    next;
+		}
 		if($cgroup =~ m@/user\@(\d+)\.service@) {
-		    print STDERR "$LOGPREF #$pid part of user manager service: uid=$1\n" if($nrconf{verbosity} > 1);
-		    push(@{ $sessions{$1}->{'user manager service'}->{ $ptable->{$pid}->{fname} } }, $pid);
+		    print STDERR "$LOGPREF #$pid part of user manager: uid=$1\n" if($nrconf{verbosity} > 1);
+		    push(@{ $sessions{$1}->{'user manager'}->{ $ptable->{$pid}->{fname} } }, $pid);
 		    next;
 		}
 		if($cgroup =~ m@/machine.slice/machine.qemu(.*).scope@) {

--- a/perl/lib/NeedRestart/Utils.pm
+++ b/perl/lib/NeedRestart/Utils.pm
@@ -43,6 +43,7 @@ our @EXPORT = qw(
     nr_fork_pipe_stderr
     nr_fork_pipew
     nr_fork_pipe2
+    nr_get_cgroup
 );
 
 my %ptable;
@@ -59,6 +60,28 @@ sub nr_ptable_pid($) {
     my $pid = shift;
 
     return $ptable{$pid};
+}
+
+sub nr_get_cgroup($) {
+    my $pid = shift;
+
+    # get unit name from /proc/<pid>/cgroup
+    if(open(HCGROUP, qq(/proc/$pid/cgroup))) {
+	my ($cgroup) = map {
+	    chomp;
+	    my ($id, $type, $value) = split(/:/);
+	    if(($id == 0 && $type eq "") || ($type eq q(name=systemd))) {
+		($value);
+	    } else {
+		();
+	    }
+	} <HCGROUP>;
+	close(HCGROUP);
+
+	return $cgroup;
+    }
+
+    return undef;
 }
 
 sub nr_parse_cmd($) {

--- a/perl/lib/NeedRestart/Utils.pm
+++ b/perl/lib/NeedRestart/Utils.pm
@@ -44,6 +44,7 @@ our @EXPORT = qw(
     nr_fork_pipew
     nr_fork_pipe2
     nr_get_cgroup
+    nr_is_systemd_manager
 );
 
 my %ptable;
@@ -82,6 +83,14 @@ sub nr_get_cgroup($) {
     }
 
     return undef;
+}
+
+sub nr_is_systemd_manager($) {
+    my $pid = shift;
+    my $cgroup = nr_get_cgroup($pid);
+
+    return $cgroup =~ m@(^|/user\@(\d+)\.service)/init\.scope$@ if($cgroup);
+    return 0;
 }
 
 sub nr_parse_cmd($) {


### PR DESCRIPTION
Right now, processes running under `systemd --user` confuse needrestart in several ways:

1. for processes that did not double-fork, needrestart considers `systemd --user` as the logical parent (which means that needrestart will bogusly report `systemd` itself as the process that needs to be restarted);
2. when the `systemd --user` instance itself needs a restart, needrestart won't do anything about it;
3. if the process to be restarted is a _user service_ under `systemd --user` (as opposed to an arbitrary process started in a user scope), needrestart won't use this information in any way.

This PR offers a clean solution for (1) by disregarding the parent if it is a `systemd --user` instance (implemented via matching the cgroup of the parent against `/init.scope$`), and pretty hacky solutions for (2) and (3) (hence the RFC status).