### PR TITLE
Containers: detect `systemd-nspawn` and add a fallback module

### DIFF
--- a/ex/restart.d/systemd-user
+++ b/ex/restart.d/systemd-user
@@ -1,0 +1,24 @@
+#!/bin/sh
+
+# needrestart - Restart daemons after library updates.
+#
+# Restarting `systemd --user` by signaling it with SIGRTMIN+25.
+# (documented in systemd(1) as equivalent to `systemctl --user daemon-reexec`,
+#  but easier to do outside of a user session)
+#
+
+# enable xtrace if we should be verbose
+if [ "$NR_VERBOSE" = '1' ]; then
+    set -x
+fi
+
+# also possible to use `--value` (systemd 230+)
+systemctl show --state=active --property=MainPID 'user@*.service' | while IFS='=' read -r _ pid; do
+    # skip empty lines produced by `systemctl show` if the property
+    # did not exist or could not be queried
+    if [ -z "$pid" ]; then continue; fi
+
+    # also possible as: `systemctl kill --kill-whom=main --signal='SIGRTMIN+25' "$unit"` (systemd 252+)
+    # also possible as: `systemctl -M "$uid@.host" --user daemon-reexec` (systemd 248+)
+    command kill -SIGRTMIN+25 "$pid"
+done

--- a/needrestart
+++ b/needrestart
@@ -706,59 +706,44 @@ if(defined($opt_l)) {
 		}
 
 		# get unit name from /proc/<pid>/cgroup
-		if(open(HCGROUP, qq(/proc/$pid/cgroup))) {
-		    my ($rc) = map {
-			chomp;
-			my ($id, $type, $value) = split(/:/);
-			if($id != 0 && $type ne q(name=systemd)) {
-			    ();
-			}
-			else {
-			    if($value =~ m@/user-(\d+)\.slice/session-(\d+)\.scope@) {
-				print STDERR "$LOGPREF #$pid part of user session: uid=$1 sess=$2\n" if($nrconf{verbosity} > 1);
-				push(@{ $sessions{$1}->{"session #$2"}->{ $ptable->{$pid}->{fname} } }, $pid);
-				next;
-			    }
-			    if($value =~ m@/user\@(\d+)\.service@) {
-				print STDERR "$LOGPREF #$pid part of user manager service: uid=$1\n" if($nrconf{verbosity} > 1);
-				push(@{ $sessions{$1}->{'user manager service'}->{ $ptable->{$pid}->{fname} } }, $pid);
-				next;
-			    }
-			    if($value =~ m@/machine.slice/machine.qemu(.*).scope@) {
-				for my $cmdlineidx (0 .. $#{$ptable->{$pid}->{cmdline}} ) {
-				    if ( ${$ptable->{$pid}->{cmdline}}[$cmdlineidx] eq "-name") {
-					foreach ( split(/,/, ${$ptable->{$pid}->{cmdline}}[$cmdlineidx+1]) ) {
-					    if ( index($_, "guest=") == 0 ) {
-						my @namearg = split(/=/, $_, 2);
-						if ($#{namearg} == 1) {
-						    print STDERR "$LOGPREF #$pid detected as VM guest '$namearg[1]' in group '$value'\n" if($nrconf{verbosity} > 1);
-						    push(@guests, __x("'{name}' with pid {pid}", name => $namearg[1], pid=>$pid) );
-						}
-						next PIDLOOP;
-					    }
-					}
+		my $cgroup = nr_get_cgroup($pid);
+		if($cgroup =~ m@/user-(\d+)\.slice/session-(\d+)\.scope@) {
+		    print STDERR "$LOGPREF #$pid part of user session: uid=$1 sess=$2\n" if($nrconf{verbosity} > 1);
+		    push(@{ $sessions{$1}->{"session #$2"}->{ $ptable->{$pid}->{fname} } }, $pid);
+		    next;
+		}
+		if($cgroup =~ m@/user\@(\d+)\.service@) {
+		    print STDERR "$LOGPREF #$pid part of user manager service: uid=$1\n" if($nrconf{verbosity} > 1);
+		    push(@{ $sessions{$1}->{'user manager service'}->{ $ptable->{$pid}->{fname} } }, $pid);
+		    next;
+		}
+		if($cgroup =~ m@/machine.slice/machine.qemu(.*).scope@) {
+		    for my $cmdlineidx (0 .. $#{$ptable->{$pid}->{cmdline}} ) {
+			if ( ${$ptable->{$pid}->{cmdline}}[$cmdlineidx] eq "-name") {
+			    foreach ( split(/,/, ${$ptable->{$pid}->{cmdline}}[$cmdlineidx+1]) ) {
+				if ( index($_, "guest=") == 0 ) {
+				    my @namearg = split(/=/, $_, 2);
+				    if ($#{namearg} == 1) {
+					print STDERR "$LOGPREF #$pid detected as VM guest '$namearg[1]' in group '$cgroup'\n" if($nrconf{verbosity} > 1);
+					push(@guests, __x("'{name}' with pid {pid}", name => $namearg[1], pid=>$pid) );
 				    }
+				    next PIDLOOP;
 				}
-				print STDERR "$LOGPREF #$pid detected as VM guest with unknown name in group '$value'\n" if($nrconf{verbosity} > 1);
-				push(@guests, __x("'Unknown VM' with pid {pid}", pid=>$pid) );
-				next;
-			    }
-			    elsif($value =~ m@/([^/]+\.service)$@) {
-				($1);
-			    }
-			    else {
-				print STDERR "$LOGPREF #$pid unexpected cgroup '$value'\n" if($nrconf{verbosity} > 1);
-				();
 			    }
 			}
-		    } <HCGROUP>;
-		    close(HCGROUP);
-
-		    if($rc) {
-			print STDERR "$LOGPREF #$pid is $rc\n" if($nrconf{verbosity} > 1);
-			$restart{$rc}++;
-			next;
 		    }
+		    print STDERR "$LOGPREF #$pid detected as VM guest with unknown name in group '$cgroup'\n" if($nrconf{verbosity} > 1);
+		    push(@guests, __x("'Unknown VM' with pid {pid}", pid=>$pid) );
+		    next;
+		}
+		elsif($cgroup =~ m@/([^/]+\.service)$@) {
+		    my $unit = $1;
+		    print STDERR "$LOGPREF #$pid is $unit\n" if($nrconf{verbosity} > 1);
+		    $restart{$unit}++;
+		    next;
+		}
+		elsif($cgroup) {
+		    print STDERR "$LOGPREF #$pid unexpected cgroup '$cgroup'\n" if($nrconf{verbosity} > 1);
 		}
 
 		# did not get the unit name, yet - try systemctl status

--- a/needrestart
+++ b/needrestart
@@ -698,15 +698,22 @@ if(defined($opt_l)) {
 	    next if(grep { $exe =~ /$_/; } @{$nrconf{blacklist}});
 
 	    if($is_systemd) {
+		# get unit name from /proc/<pid>/cgroup
+		my $cgroup = nr_get_cgroup($pid);
 		# systemd manager
-		if($pid == 1 && $exe =~ m@^(/usr)?/lib/systemd/systemd@) {
+		if($cgroup =~ m@^/init\.scope$@ || ($pid == 1 && $exe =~ m@^(/usr)?/lib/systemd/systemd@)) {
 		    print STDERR "$LOGPREF #$pid is systemd manager\n" if($nrconf{verbosity} > 1);
 		    $restart{q(systemd-manager)}++;
 		    next;
 		}
+		# `systemd --user` manager
+		if($cgroup =~ m@/user\@(\d+)\.service/init\.scope$@ && $ptable->{$pid}->{fname} ne "(sd-pam)") {
+		    print STDERR "$LOGPREF #$pid is user systemd manager: uid=$1\n" if($nrconf{verbosity} > 1);
+		    # TODO: restart specific `systemd --user` instance?
+		    $restart{q(systemd-user)}++;
+		    next;
+		}
 
-		# get unit name from /proc/<pid>/cgroup
-		my $cgroup = nr_get_cgroup($pid);
 		if($cgroup =~ m@/user-(\d+)\.slice/session-(\d+)\.scope@) {
 		    print STDERR "$LOGPREF #$pid part of user session: uid=$1 sess=$2\n" if($nrconf{verbosity} > 1);
 		    push(@{ $sessions{$1}->{"session #$2"}->{ $ptable->{$pid}->{fname} } }, $pid);

--- a/needrestart
+++ b/needrestart
@@ -724,20 +724,20 @@ if(defined($opt_l)) {
 				push(@{ $sessions{$1}->{'user manager service'}->{ $ptable->{$pid}->{fname} } }, $pid);
 				next;
 			    }
-				if($value =~ m@/machine.slice/machine.qemu(.*).scope@) {
+			    if($value =~ m@/machine.slice/machine.qemu(.*).scope@) {
 				for my $cmdlineidx (0 .. $#{$ptable->{$pid}->{cmdline}} ) {
-					if ( ${$ptable->{$pid}->{cmdline}}[$cmdlineidx] eq "-name") {
-						foreach ( split(/,/, ${$ptable->{$pid}->{cmdline}}[$cmdlineidx+1]) ) {
-							if ( index($_, "guest=") == 0 ) {
-								my @namearg = split(/=/, $_, 2);
-								if ($#{namearg} == 1) {
-									print STDERR "$LOGPREF #$pid detected as VM guest '$namearg[1]' in group '$value'\n" if($nrconf{verbosity} > 1);
-									push(@guests, __x("'{name}' with pid {pid}", name => $namearg[1], pid=>$pid) );
-								}
-								next PIDLOOP;
-							}
+				    if ( ${$ptable->{$pid}->{cmdline}}[$cmdlineidx] eq "-name") {
+					foreach ( split(/,/, ${$ptable->{$pid}->{cmdline}}[$cmdlineidx+1]) ) {
+					    if ( index($_, "guest=") == 0 ) {
+						my @namearg = split(/=/, $_, 2);
+						if ($#{namearg} == 1) {
+						    print STDERR "$LOGPREF #$pid detected as VM guest '$namearg[1]' in group '$value'\n" if($nrconf{verbosity} > 1);
+						    push(@guests, __x("'{name}' with pid {pid}", name => $namearg[1], pid=>$pid) );
 						}
+						next PIDLOOP;
+					    }
 					}
+				    }
 				}
 				print STDERR "$LOGPREF #$pid detected as VM guest with unknown name in group '$value'\n" if($nrconf{verbosity} > 1);
 				push(@guests, __x("'Unknown VM' with pid {pid}", pid=>$pid) );

--- a/needrestart
+++ b/needrestart
@@ -654,7 +654,7 @@ if(defined($opt_l)) {
 
 	# find parent process
 	my $ppid = $ptable->{$pid}->{ppid};
-	if($ppid != $pid && $ppid > 1 && !$uid) {
+	if($ppid != $pid && $ppid > 1) {
 	    print STDERR "$LOGPREF #$pid is a child of #$ppid\n" if($nrconf{verbosity} > 1);
 
 	    if($uid && $ptable->{$ppid}->{uid} != $uid) {

--- a/needrestart
+++ b/needrestart
@@ -654,7 +654,7 @@ if(defined($opt_l)) {
 
 	# find parent process
 	my $ppid = $ptable->{$pid}->{ppid};
-	if($ppid != $pid && $ppid > 1) {
+	if($ppid != $pid && $ppid > 1 && !($is_systemd && nr_is_systemd_manager($ppid))) {
 	    print STDERR "$LOGPREF #$pid is a child of #$ppid\n" if($nrconf{verbosity} > 1);
 
 	    if($uid && $ptable->{$ppid}->{uid} != $uid) {

--- a/needrestart
+++ b/needrestart
@@ -719,9 +719,14 @@ if(defined($opt_l)) {
 		    push(@{ $sessions{$1}->{"session #$2"}->{ $ptable->{$pid}->{fname} } }, $pid);
 		    next;
 		}
+		if($cgroup =~ m@/user\@(\d+)\.service(/.+\.slice)*/([^/]+\.service)$@) {
+		    print STDERR "$LOGPREF #$pid part of user service: uid=$1 unit=$3\n" if($nrconf{verbosity} > 1);
+		    push(@{ $sessions{$1}->{'user service'}->{ $3 } }, $pid);
+		    next;
+		}
 		if($cgroup =~ m@/user\@(\d+)\.service@) {
-		    print STDERR "$LOGPREF #$pid part of user manager service: uid=$1\n" if($nrconf{verbosity} > 1);
-		    push(@{ $sessions{$1}->{'user manager service'}->{ $ptable->{$pid}->{fname} } }, $pid);
+		    print STDERR "$LOGPREF #$pid part of user manager: uid=$1\n" if($nrconf{verbosity} > 1);
+		    push(@{ $sessions{$1}->{'user manager'}->{ $ptable->{$pid}->{fname} } }, $pid);
 		    next;
 		}
 		if($cgroup =~ m@/machine.slice/machine.qemu(.*).scope@) {

--- a/perl/lib/NeedRestart.pm
+++ b/perl/lib/NeedRestart.pm
@@ -62,6 +62,7 @@ our @EXPORT_OK = qw(
     needrestart_ui_init
     needrestart_interp_register
     needrestart_cont_register
+    needrestart_cont_register_fallback
 );
 
 our %EXPORT_TAGS = (
@@ -78,6 +79,7 @@ our %EXPORT_TAGS = (
     )],
     cont => [qw(
 	needrestart_cont_register
+	needrestart_cont_register_fallback
     )],
 );
 
@@ -224,12 +226,19 @@ sub needrestart_interp_source($$$) {
 
 
 my %CONT;
+my %FALLBACK;
 my $ndebug;
 
 sub needrestart_cont_register($) {
     my $pkg = shift;
 
     $CONT{$pkg} = new $pkg($ndebug);
+}
+
+sub needrestart_cont_register_fallback($) {
+    my $pkg = shift;
+
+    $FALLBACK{$pkg} = new $pkg($ndebug);
 }
 
 sub needrestart_cont_init($) {
@@ -252,6 +261,9 @@ sub needrestart_cont_check($$$;$) {
     needrestart_cont_init($debug) unless(scalar keys %CONT);
 
     foreach my $cont (values %CONT) {
+	return 1 if($cont->check($pid, $bin, $norestart));
+    }
+    foreach my $cont (values %FALLBACK) {
 	return 1 if($cont->check($pid, $bin, $norestart));
     }
 

--- a/perl/lib/NeedRestart/CONT.pm
+++ b/perl/lib/NeedRestart/CONT.pm
@@ -57,6 +57,14 @@ sub get {
     return ();
 }
 
+sub in_pidns {
+    my $self = shift;
+    my $pid = shift;
+
+    my $ns = nr_get_pid_ns($pid);
+    return $ns && $ns != $self->{pidns};
+}
+
 sub find_nsparent {
     my $self = shift;
     my $pid = shift;

--- a/perl/lib/NeedRestart/CONT.pm
+++ b/perl/lib/NeedRestart/CONT.pm
@@ -30,16 +30,18 @@ use NeedRestart::Utils;
 
 my $LOGPREF = '[CONT]';
 
-my $nspid = nr_get_pid_ns(1);
+my $root_pidns = nr_get_pid_ns(1);
 my $ptable = nr_ptable();
 
 sub new {
     my $class = shift;
     my $debug = shift;
 
+    die "Could not get PID namespace of #1!\n" unless(defined($root_pidns));
+
     return bless {
 	debug => $debug,
-	nspid => $nspid,
+	pidns => $root_pidns,
     }, $class;
 }
 
@@ -63,7 +65,7 @@ sub find_nsparent {
 
     my $ns = nr_get_pid_ns($ptable->{$pid}->{ppid});
 
-    return $ptable->{$pid}->{ppid} if($ns && $ns == $nspid);
+    return $ptable->{$pid}->{ppid} if($ns && $ns == $self->{pidns});
 
     return $self->find_nsparent($ptable->{$pid}->{ppid});
 }

--- a/perl/lib/NeedRestart/CONT.pm
+++ b/perl/lib/NeedRestart/CONT.pm
@@ -30,7 +30,7 @@ use NeedRestart::Utils;
 
 my $LOGPREF = '[CONT]';
 
-my $nspid = get_nspid(undef, 1);
+my $nspid = nr_get_pid_ns(1);
 my $ptable = nr_ptable();
 
 sub new {
@@ -55,24 +55,13 @@ sub get {
     return ();
 }
 
-sub get_nspid {
-    my $self = shift;
-    my $pid = shift;
-
-    my $stat = nr_stat(qq(/proc/$pid/ns/pid));
-
-    return $stat->{ino} if($stat);
-
-    return undef;
-}
-
 sub find_nsparent {
     my $self = shift;
     my $pid = shift;
 
     return undef unless(exists($ptable->{$pid}));
 
-    my $ns = $self->get_nspid($ptable->{$pid}->{ppid});
+    my $ns = nr_get_pid_ns($ptable->{$pid}->{ppid});
 
     return $ptable->{$pid}->{ppid} if($ns && $ns == $nspid);
 

--- a/perl/lib/NeedRestart/CONT/LXC.pm
+++ b/perl/lib/NeedRestart/CONT/LXC.pm
@@ -40,7 +40,6 @@ sub new {
     my $class = shift;
 
     my $self = $class->SUPER::new(@_);
-    die "Could not get NS PID of #1!\n" unless(defined($self->{nspid}));
 
     $self->{lxc} = {};
     $self->{lxd} = {};
@@ -71,7 +70,7 @@ sub check {
     my $ns = nr_get_pid_ns($pid);
 
     # stop here if no dedicated PID namespace is used
-    return 0 if(!$ns || $ns == $self->{nspid});
+    return 0 if(!$ns || $ns == $self->{pidns});
 
     my $cg = nr_get_cgroup($pid);
 

--- a/perl/lib/NeedRestart/CONT/LXC.pm
+++ b/perl/lib/NeedRestart/CONT/LXC.pm
@@ -67,10 +67,9 @@ sub check {
     my $pid = shift;
     my $bin = shift;
     my $norestart = shift;
-    my $ns = nr_get_pid_ns($pid);
 
     # stop here if no dedicated PID namespace is used
-    return 0 if(!$ns || $ns == $self->{pidns});
+    return 0 unless $self->in_pidns($pid);
 
     my $cg = nr_get_cgroup($pid);
 

--- a/perl/lib/NeedRestart/CONT/LXC.pm
+++ b/perl/lib/NeedRestart/CONT/LXC.pm
@@ -68,7 +68,7 @@ sub check {
     my $pid = shift;
     my $bin = shift;
     my $norestart = shift;
-    my $ns = $self->get_nspid($pid);
+    my $ns = nr_get_pid_ns($pid);
 
     # stop here if no dedicated PID namespace is used
     return 0 if(!$ns || $ns == $self->{nspid});

--- a/perl/lib/NeedRestart/CONT/LXC.pm
+++ b/perl/lib/NeedRestart/CONT/LXC.pm
@@ -73,19 +73,10 @@ sub check {
     # stop here if no dedicated PID namespace is used
     return 0 if(!$ns || $ns == $self->{nspid});
 
-    unless(open(FCG, qq(/proc/$pid/cgroup))) {
-	print STDERR "$LOGPREF #$pid: unable to open cgroup ($!)\n" if($self->{debug});
-	return 0;
-    }
-    my $cg;
-    {
-	local $/;
-	$cg = <FCG>;
-	close(FCG);
-    }
+    my $cg = nr_get_cgroup($pid);
 
     # look for LXC cgroups
-    return unless($cg =~ /^\d+:[^:]*:\/lxc(?:.payload)?[.\/]([^\/\n]+)($|\/)/m);
+    return unless($cg =~ m@^/lxc(?:.payload)?[./]([^/\n]+)($|/)@);
 
     my $name = $1;
     my $type = ($self->{has_lxd} && -d qq($self->{lxd_container_path}/$name) ? 'LXD' : 'LXC');

--- a/perl/lib/NeedRestart/CONT/docker.pm
+++ b/perl/lib/NeedRestart/CONT/docker.pm
@@ -40,7 +40,6 @@ sub new {
     my $class = shift;
 
     my $self = $class->SUPER::new(@_);
-    die "Could not get NS PID of #1!\n" unless(defined($self->{nspid}));
 
     return bless $self, $class;
 }
@@ -53,7 +52,7 @@ sub check {
     my $ns = nr_get_pid_ns($pid);
 
     # stop here if no dedicated PID namespace is used
-    return 0 if(!$ns || $ns == $self->{nspid});
+    return 0 if(!$ns || $ns == $self->{pidns});
 
     my $cg = nr_get_cgroup($pid);
 

--- a/perl/lib/NeedRestart/CONT/docker.pm
+++ b/perl/lib/NeedRestart/CONT/docker.pm
@@ -49,10 +49,9 @@ sub check {
     my $pid = shift;
     my $bin = shift;
     my $norestart = shift;
-    my $ns = nr_get_pid_ns($pid);
 
     # stop here if no dedicated PID namespace is used
-    return 0 if(!$ns || $ns == $self->{pidns});
+    return 0 unless $self->in_pidns($pid);
 
     my $cg = nr_get_cgroup($pid);
 

--- a/perl/lib/NeedRestart/CONT/docker.pm
+++ b/perl/lib/NeedRestart/CONT/docker.pm
@@ -50,7 +50,7 @@ sub check {
     my $pid = shift;
     my $bin = shift;
     my $norestart = shift;
-    my $ns = $self->get_nspid($pid);
+    my $ns = nr_get_pid_ns($pid);
 
     # stop here if no dedicated PID namespace is used
     return 0 if(!$ns || $ns == $self->{nspid});

--- a/perl/lib/NeedRestart/CONT/machined.pm
+++ b/perl/lib/NeedRestart/CONT/machined.pm
@@ -56,19 +56,10 @@ sub check {
     # stop here if no dedicated PID namespace is used
     return 0 if(!$ns || $ns == $self->{nspid});
 
-    unless(open(FCG, qq(/proc/$pid/cgroup))) {
-	print STDERR "$LOGPREF #$pid: unable to open cgroup ($!)\n" if($self->{debug});
-	return 0;
-    }
-    my $cg;
-    {
-	local $/;
-	$cg = <FCG>;
-	close(FCG);
-    }
+    my $cg = nr_get_cgroup($pid);
 
     # look for machined cgroups
-    return 0 unless($cg =~ /^\d+:[^:]*:\/machine.slice\/machine-(.+)\.scope$/m);
+    return 0 unless($cg =~ m@^/machine\.slice/machine-(.+)\.scope$@m);
 
     my $name = $1;
     unless($norestart) {

--- a/perl/lib/NeedRestart/CONT/machined.pm
+++ b/perl/lib/NeedRestart/CONT/machined.pm
@@ -40,7 +40,6 @@ sub new {
     my $class = shift;
 
     my $self = $class->SUPER::new(@_);
-    die "Could not get NS PID of #1!\n" unless(defined($self->{nspid}));
 
     $self->{machined} = {};
     return bless $self, $class;
@@ -54,7 +53,7 @@ sub check {
     my $ns = nr_get_pid_ns($pid);
 
     # stop here if no dedicated PID namespace is used
-    return 0 if(!$ns || $ns == $self->{nspid});
+    return 0 if(!$ns || $ns == $self->{pidns});
 
     my $cg = nr_get_cgroup($pid);
 

--- a/perl/lib/NeedRestart/CONT/machined.pm
+++ b/perl/lib/NeedRestart/CONT/machined.pm
@@ -51,7 +51,7 @@ sub check {
     my $pid = shift;
     my $bin = shift;
     my $norestart = shift;
-    my $ns = $self->get_nspid($pid);
+    my $ns = nr_get_pid_ns($pid);
 
     # stop here if no dedicated PID namespace is used
     return 0 if(!$ns || $ns == $self->{nspid});

--- a/perl/lib/NeedRestart/CONT/machined.pm
+++ b/perl/lib/NeedRestart/CONT/machined.pm
@@ -56,17 +56,20 @@ sub check {
 
     my $cg = nr_get_cgroup($pid);
 
-    # look for machined cgroups
-    return 0 unless($cg =~ m@^/machine\.slice/machine-(.+)\.scope$@m);
+    # look for machined or systemd-nspawn cgroups
+    return 0 unless($cg =~ m@^/machine\.slice/(machine)-([^.]+)\.scope(/|$)@m ||
+                    $cg =~ m@^/machine\.slice/(systemd-nspawn)\@([^.]+)\.service(/|$)@);
 
-    my $name = $1;
+    my $name = $2;
+    my $mgr = ($1 eq "machine") ? "systemd-machined" : $1;
+
     unless($norestart) {
-	print STDERR "$LOGPREF #$pid is part of systemd-machined container '$name' and should be restarted\n" if($self->{debug});
+	print STDERR "$LOGPREF #$pid is part of $mgr container '$name' and should be restarted\n" if($self->{debug});
 
 	$self->{machined}->{$name}++;
     }
     else {
-	print STDERR "$LOGPREF #$pid is part of systemd-machined container '$name'\n" if($self->{debug});
+	print STDERR "$LOGPREF #$pid is part of $mgr container '$name'\n" if($self->{debug});
     }
 
     return 1;

--- a/perl/lib/NeedRestart/CONT/machined.pm
+++ b/perl/lib/NeedRestart/CONT/machined.pm
@@ -50,10 +50,9 @@ sub check {
     my $pid = shift;
     my $bin = shift;
     my $norestart = shift;
-    my $ns = nr_get_pid_ns($pid);
 
     # stop here if no dedicated PID namespace is used
-    return 0 if(!$ns || $ns == $self->{pidns});
+    return 0 unless $self->in_pidns($pid);
 
     my $cg = nr_get_cgroup($pid);
 

--- a/perl/lib/NeedRestart/CONT/other.pm
+++ b/perl/lib/NeedRestart/CONT/other.pm
@@ -1,0 +1,67 @@
+# needrestart - Restart daemons after library updates.
+#
+# Authors:
+#   Thomas Liske <thomas@fiasko-nw.net>
+#
+# Copyright Holder:
+#   2013 - 2022 (C) Thomas Liske [http://fiasko-nw.net/~thomas/]
+#
+# License:
+#   This program is free software; you can redistribute it and/or modify
+#   it under the terms of the GNU General Public License as published by
+#   the Free Software Foundation; either version 2 of the License, or
+#   (at your option) any later version.
+#
+#   This program is distributed in the hope that it will be useful,
+#   but WITHOUT ANY WARRANTY; without even the implied warranty of
+#   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#   GNU General Public License for more details.
+#
+#   You should have received a copy of the GNU General Public License
+#   along with this package; if not, write to the Free Software
+#   Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301 USA
+#
+
+package NeedRestart::CONT::other;
+
+use strict;
+use warnings;
+
+use parent qw(NeedRestart::CONT);
+use NeedRestart qw(:cont);
+use NeedRestart::Utils;
+
+my $LOGPREF = '[other]';
+
+needrestart_cont_register_fallback(__PACKAGE__)
+    unless($<);
+
+sub new {
+    my $class = shift;
+
+    my $self = $class->SUPER::new(@_);
+
+    return bless $self, $class;
+}
+
+sub check {
+    my $self = shift;
+    my $pid = shift;
+    my $bin = shift;
+    my $norestart = shift;
+
+    # stop here if no dedicated PID namespace is used
+    return 0 unless $self->in_pidns($pid);
+
+    print STDERR "$LOGPREF #$pid is part of a PID namespace and will be ignored\n" if($self->{debug});
+
+    return 1;
+}
+
+sub get {
+    my $self = shift;
+
+    return ();
+}
+
+1;

--- a/perl/lib/NeedRestart/Utils.pm
+++ b/perl/lib/NeedRestart/Utils.pm
@@ -43,6 +43,7 @@ our @EXPORT = qw(
     nr_fork_pipe_stderr
     nr_fork_pipew
     nr_fork_pipe2
+    nr_get_cgroup
 );
 
 my %ptable;
@@ -59,6 +60,28 @@ sub nr_ptable_pid($) {
     my $pid = shift;
 
     return $ptable{$pid};
+}
+
+sub nr_get_cgroup($) {
+    my $pid = shift;
+
+    # get unit name from /proc/<pid>/cgroup
+    if(open(HCGROUP, qq(/proc/$pid/cgroup))) {
+	my ($cgroup) = map {
+	    chomp;
+	    my ($id, $type, $value) = split(/:/);
+	    if(($id == 0 && $type eq "") || ($type eq q(name=systemd))) {
+		($value);
+	    } else {
+		();
+	    }
+	} <HCGROUP>;
+	close(HCGROUP);
+
+	return $cgroup;
+    }
+
+    return undef;
 }
 
 sub nr_parse_cmd($) {

--- a/perl/lib/NeedRestart/Utils.pm
+++ b/perl/lib/NeedRestart/Utils.pm
@@ -45,6 +45,8 @@ our @EXPORT = qw(
     nr_fork_pipe2
     nr_get_cgroup
     nr_is_systemd_manager
+    nr_get_ns
+    nr_get_pid_ns
 );
 
 my %ptable;
@@ -91,6 +93,21 @@ sub nr_is_systemd_manager($) {
 
     return $cgroup =~ m@(^|/user\@(\d+)\.service)/init\.scope$@ if($cgroup);
     return 0;
+}
+
+sub nr_get_ns($$) {
+    my $pid = shift;
+    my $ns = shift;
+
+    my $stat = nr_stat(qq(/proc/$pid/ns/$ns));
+
+    return $stat->{ino} if($stat);
+    return undef;
+}
+
+sub nr_get_pid_ns($) {
+    my $pid = shift;
+    return nr_get_ns($pid, 'pid');
 }
 
 sub nr_parse_cmd($) {

--- a/perl/lib/NeedRestart/Utils.pm
+++ b/perl/lib/NeedRestart/Utils.pm
@@ -44,6 +44,7 @@ our @EXPORT = qw(
     nr_fork_pipew
     nr_fork_pipe2
     nr_get_cgroup
+    nr_is_systemd_manager
 );
 
 my %ptable;
@@ -82,6 +83,14 @@ sub nr_get_cgroup($) {
     }
 
     return undef;
+}
+
+sub nr_is_systemd_manager($) {
+    my $pid = shift;
+    my $cgroup = nr_get_cgroup($pid);
+
+    return $cgroup =~ m@(^|/user\@(\d+)\.service)/init\.scope$@ if($cgroup);
+    return 0;
 }
 
 sub nr_parse_cmd($) {


### PR DESCRIPTION
This is on top of #301.

This PR does two things:
- updates `CONT::machined` module to also check for systemd-nspawn containers (which is slightly dirty, but I opted to keep it in the same module for now because the restart call is the same);
- adds a special `CONT::other` module that runs after all others to detect any containers of unknown type by pidns.