### PR TITLE
Update README for RPi 1 & RPi 1B

### DIFF
--- a/README.raspberry.md
+++ b/README.raspberry.md
@@ -13,6 +13,16 @@ This might result in a continuous pending kernel update false positive. There
 is a configuration option in needrestart to filter the kernel image filenames to
 ignore the unused image files.
 
+### RPi 1 or RPi 1B
+
+```shell
+$ cat << 'EOF' > /etc/needrestart/conf.d/kernel.conf
+# Filter kernel image filenames by regex. This is required on Raspian having
+# multiple kernel image variants installed in parallel.
+$nrconf{kernelfilter} = qr(vmlinuz-.*-v6$);
+EOF
+```
+
 ### RPi 2 or RPi 3
 
 ```shell


### PR DESCRIPTION
Hello @liske,

I managed to get needrestart working on RPi 1 and 1B also with a workaround.
I felt like I could share my findings (fix is very much straightforward).

I hope you can merge this to your README to help others.

Thanks for this great tool.

Kind regards.