### PR TITLE
Support `ucodehints=-1` like `kernelhints=-1`

### DIFF
--- a/needrestart
+++ b/needrestart
@@ -978,7 +978,15 @@ if($opt_w) {
 	    elsif($ucode_result == NRM_OBSOLETE) {
             push(@easy_hints, __ 'outdated processor microcode') if($opt_m eq 'e');
 
-            if($nrconf{ucodehints}) {
+            if($nrconf{ucodehints} < 0) {
+                $ui->vspace();
+                $ui->notice(__x(
+                    'The currently running processor microcode revision is {crev} which is not the expected microcode revision {erev}.',
+                    crev => $ucode_vars{CURRENT},
+                    erev => $ucode_vars{AVAIL},
+                ));
+            }
+            elsif($nrconf{ucodehints}) {
                 $ui->announce_ucode(%ucode_vars);
             }
 	    }


### PR DESCRIPTION
Presently the options are to force the user to acknowledge, or disable the check entirely. This is a 3rd option, similar to `kernelhints=-1` that prints the same info without forcing user interaction.