### PR TITLE
Fix Spelling Mistake

### DIFF
--- a/needrestart
+++ b/needrestart
@@ -712,7 +712,7 @@ if(defined($opt_l)) {
 					}
 				}
 				print STDERR "$LOGPREF #$pid detected as VM guest with unknown name in group '$value'\n" if($nrconf{verbosity} > 1);
-				push(@guests, __x("'Unkown VM' with pid {pid}", pid=>$pid) );
+				push(@guests, __x("'Unknown VM' with pid {pid}", pid=>$pid) );
 				next;
 			    }
 			    elsif($value =~ m@/([^/]+\.service)$@) {


### PR DESCRIPTION
Debian packaging maintainers spotted this typo:
https://sources.debian.org/patches/needrestart/3.7-2/11-spelling-error.diff/