### PR TITLE
[uCode] fix error handling logic being dependent on debug level, leading to "Use of uninitialized value $ucode_vars..." for non-verbose batch mode (-b) on Intel CPUs

### DIFF
--- a/perl/lib/NeedRestart/uCode.pm
+++ b/perl/lib/NeedRestart/uCode.pm
@@ -154,8 +154,9 @@ sub nr_ucode_check {
         foreach my $pkg (@PKGS) {
             my @nvars;
             eval "\@nvars = ${pkg}::nr_ucode_check_real(\$debug, \$ui, \$processors{\$pid});";
-            if ( $@ && $debug ) {
-                print STDERR $@;
+            if ( $@ ) {
+                print STDERR $@
+                    if ($debug);
                 $ui->progress_step;
                 next;
             }


### PR DESCRIPTION
The bug was introduced in f8c2609f8d5a0e10bd988497b8ea9815a7bb2fa8 (see https://github.com/liske/needrestart/commit/f8c2609f8d5a0e10bd988497b8ea9815a7bb2fa8#diff-22b45c8ce7df32d7f5f4fd1f5bbd262f42e168b2f6dcc6972b21d9a3681c7599R147)