### PR TITLE
Try to fix "Use of uninitialized value $sdev in right bitshift"

### DIFF
--- a/needrestart
+++ b/needrestart
@@ -573,6 +573,12 @@ if(defined($opt_l)) {
 
 			# get on-disk info
 			my ($sdev, $sinode) = stat($testp);
+			unless($sdev) {
+			    unless($nrconf{skip_mapfiles} == -1) {
+				print STDERR "$LOGPREF #$pid map stat for $testp failed: $!\n" if($nrconf{verbosity} > 1);
+			    }
+                next;
+            }
 			my @sdevs = (
 			    # glibc gnu_dev_* definition from sysmacros.h
 			    sprintf("%02x:%02x", (($sdev >> 8) & 0xfff) | (($sdev >> 32) & ~0xfff), (($sdev & 0xff) | (($sdev >> 12) & ~0xff))),


### PR DESCRIPTION
See #296 

I'm not sure about the verbosity check (is it needed in this case?), it might be better if the message is printed always for debugging. On the other hand, someone (or more specifically some tool) might not expect this output, so I can't decide this by myself.