### PR TITLE
fix blacklisting of perl files via blacklist_interp

### DIFF
--- a/perl/lib/NeedRestart/Interp/Perl.pm
+++ b/perl/lib/NeedRestart/Interp/Perl.pm
@@ -55,7 +55,7 @@ sub _scan($$$$$) {
     my $path = shift;
 
     my $fh;
-    open($fh, '<', $src) || return;
+    open($fh, '<', "/proc/$pid/root/$src") || return;
     # find used modules
     my %modules = map {
 	(/^\s*use\s+([a-zA-Z][\w:]+)/ ? ($1 => 1) : ())
@@ -200,12 +200,12 @@ sub files {
     # get include path from env
     my %e = nr_parse_env($pid);
     if(exists($e{PERL5LIB})) {
-	@path = map { "/proc/$pid/root/$_"; } split(':', $e{PERL5LIB});
+	@path = split(':', $e{PERL5LIB});
     }
 
     # get include path from @INC
     my $plread = nr_fork_pipe($self->{debug}, $ptable->{exec}, '-e', 'print(join("\n", @INC));');
-    push(@path, map { "/proc/$pid/root/$_"; } <$plread>);
+    push(@path, <$plread>);
     close($plread);
     chomp(@path);
 


### PR DESCRIPTION
In 0f80a348883f72279a859ee655f58da34babefb0, the files() method started returning paths like:

    /proc/521178/root//usr/share/perl5/Foo/Bar.pm

...rather than:

    /usr/share/perl5/Foo/Bar.pm

This breaks the use of configuration such as:

    $nrconf{blacklist_interp} = [
        @{$nrconf{blacklist_interp}},
        qr(^/usr/share/perl5/Foo/),
    ];

If I understand correctly, the intent is to scan files within the per-process root as described in proc_pid_root(5). This patch should still respect that.

Notes:
* The code is already statting files within the per-process root; without this patch, the paths to stat have `/proc/<pid>/root/` prepended twice, resulting in e.g.: `/proc/521178/root//proc/521178/root//usr/share/perl5/Foo/Bar.pm` With this patch, `/proc/<pid>/root/` is only prepended once.
* Without this patch, when files are read in _scan(), the executable script (e.g. `/usr/local/bin/foo.pl`) is not opened using the path to the per-process root. With this patch, all files are opened using the per-process root.
* With this patch, `needrestart -v` prints paths without the per-process root, matching earlier behavior.
* This behavior may apply to other interpreters as well; I have only examined the handling of Perl.