### PR TITLE
Update kernelfilter for RPi 2/3

### DIFF
--- a/README.raspberry.md
+++ b/README.raspberry.md
@@ -29,7 +29,7 @@ EOF
 $ cat << 'EOF' > /etc/needrestart/conf.d/kernel.conf
 # Filter kernel image filenames by regex. This is required on Raspian having
 # multiple kernel image variants installed in parallel.
-$nrconf{kernelfilter} = qr(kernel7\.img);
+$nrconf{kernelfilter} = qr(vmlinuz-.*-v7$);
 EOF
 ```
 


### PR DESCRIPTION
I have verified that this is the correct setting on the Raspberry Pi 3 Model B (Non-Plus) on the latest Raspbian. I have _not_ verified it on any other RPi 2/3 model. The old previously recommended setting would break expected kernel version detection completely.