### PR TITLE
Add default override for qrtr-ns / rmtfs

### DIFF
--- a/ex/needrestart.conf
+++ b/ex/needrestart.conf
@@ -112,6 +112,9 @@ $nrconf{override_rc} = {
     qr(^virtlogd) => 0,
     qr(^virtlockd) => 0,
     qr(^docker) => 0,
+    # see Debian bugs #1095222 & #1095223
+    qr(^qrtr-ns) => 0,
+    qr(^rmtfs) => 0,
 
     # systemd stuff
     # (see also Debian Bug#784238 & #784437)


### PR DESCRIPTION
Those services run on Qualcomm-based devices, handling the communication with remote processors such as the WiFi or audio DSP. Restarting them usually causes the device to crash[1][2], so they should be added to the default selection override list.

[1] https://bugs.debian.org/1095222
[2] https://bugs.debian.org/1095223