### PR TITLE
document -b a little more

### DIFF
--- a/man/needrestart.1
+++ b/man/needrestart.1
@@ -44,7 +44,7 @@ set restart mode
 \fBATTENTION:\fR If needrestart is configured to run in interactive mode but is run non-interactive (i.e. unattended-upgrades) it will fallback to list only mode.
 .TP
 \fB\-b\fR
-enable batch mode
+enable batch mode: don't restart anything and produce machine-readable output.
 .TP
 \fB\-p\fR
 nagios plugin mode: makes output and exit codes nagios compatible


### PR DESCRIPTION
The existing man page explanation of `-b` is rather sparse and doesn't explain much about its usefulness. The man page probably ought to explain batch mode fully, but frankly, I don't want to deal with writing roff.