### PR TITLE
More dbus deps

### DIFF
--- a/ex/restart.d/dbus.service
+++ b/ex/restart.d/dbus.service
@@ -14,6 +14,13 @@
 # delay in semi-interactive mode
 DELAY_SECONDS=10
 
+# extra dependencies to be conditionally appended to found dependencies
+# match.service=add1.service add2.service ...
+# no extra spaces
+EXTRA_DEPS='
+systemd-networkd.service=networkd-dispatcher.service
+'
+
 # enable xtrace if we should be verbose
 if [ "$NR_VERBOSE" = '1' ]; then
 	set -x
@@ -51,8 +58,8 @@ DBUS_SERVICE_NAME=$(
 
 # if DM is active, return canonical ID
 DISPLAY_MANAGER=$(
-	systemctl -q is-active display-manager.service \
-		&& systemctl show --value -p Id display-manager.service
+	systemctl -q is-active display-manager.service &&
+		systemctl show --value -p Id display-manager.service
 )
 
 # get active dependencies
@@ -76,28 +83,29 @@ done <<- EOF
 	)
 EOF
 
-# get active services with BusName
-current_busname=''
-current_id=''
+# get active services with BusName, or Type=dbus, or dbus-org.* in Names
+reset_iter_values() {
+	current_busname=''
+	current_id=''
+	current_names=''
+	current_type=''
+}
 while IFS='=' read -r option value; do
 	case "${option}" in
-	BusName)
-		current_busname="$value"
-		continue
-		;;
-	Id)
-		current_id="$value"
-		continue
-		;;
+	BusName) current_busname="$value" ;;
+	Id) current_id="$value" ;;
+	Type) current_type="$value" ;;
+	Names) current_names="$value" ;;
 	'')
-		if [ -z "$current_busname" ] || [ -z "$current_id" ]; then
-			current_busname=''
-			current_id=''
+		# skip if nothing matches
+		if [ -z "$current_busname" ] &&
+			[ "$current_type" != 'dbus' ] &&
+			case " $current_names " in *' dbus-org.'*) false ;; *) true ;; esac then
+			reset_iter_values
 			continue
 		fi
+
 		service=$current_id
-		current_busname=''
-		current_id=''
 		case "$service" in
 		"$DISPLAY_MANAGER" | dbus.service | "$DBUS_SERVICE_NAME") continue ;;
 		esac
@@ -105,20 +113,42 @@ while IFS='=' read -r option value; do
 		*" $service "*) true ;;
 		*) ACTIVE_DEPS="${ACTIVE_DEPS}${ACTIVE_DEPS:+ }${service}" ;;
 		esac
+		reset_iter_values
 		;;
-	*)
-		current_busname=''
-		current_id=''
-		;;
+	*) reset_iter_values ;;
 	esac
 done <<- EOF
 	$(
 		systemctl show --plain --all \
 			--type=service \
 			--state=active,reloading,failed,activating \
-			--property=BusName,Id
+			--property=BusName \
+			--property=Id \
+			--property=Names \
+			--property=Type \
+			'*'
 	)
 	=end
+EOF
+
+# conditionally chain additional deps
+while IFS='=' read -r match_unit add_units; do
+	if [ -z "$match_unit" ] || [ -z "$add_units" ]; then
+		continue
+	fi
+	case " $ACTIVE_DEPS " in
+	*" $match_unit "*)
+		# shellcheck disable=SC2086
+		for add_unit in $add_units; do
+			case " $ACTIVE_DEPS " in
+			*" $add_unit "*) true ;;
+			*) ACTIVE_DEPS="${ACTIVE_DEPS}${ACTIVE_DEPS:+ }${add_unit}" ;;
+			esac
+		done
+		;;
+	esac
+done <<- EOF
+	$EXTRA_DEPS
 EOF
 
 # get logind users

--- a/ex/restart.d/dbus.service
+++ b/ex/restart.d/dbus.service
@@ -192,7 +192,6 @@ shcat() {
 	done
 }
 
-# shellcheck disable=SC2086
 case "$CONSOLE_MODE" in
 interactive) shcat ;;
 delay) shcat >&2 ;;
@@ -202,10 +201,16 @@ esac <<- EOF
 	!!! $DBUS_SERVICE_NAME restart will be performed !!!
 
 	Users to be terminated:
-	$(printf '  %s\n' $USERS)
+	$(
+		# shellcheck disable=SC2086
+		printf '  %s\n' $USERS
+	)
 
 	Services to be restarted:
-	$(printf '  %s\n' $ACTIVE_DEPS)
+	$(
+		# shellcheck disable=SC2086
+		printf '  %s\n' $ACTIVE_DEPS
+	)
 
 	Display manager to be restarted: ${DISPLAY_MANAGER:-no active DM found}
 
@@ -214,6 +219,7 @@ esac <<- EOF
 		IFS=';'
 		# consequent commands have a space after preceding semicolons, compensate for that
 		printf '%s' ' '
+		# shellcheck disable=SC2086
 		printf ' %s\n' $COMMANDS
 	)
 
@@ -236,4 +242,9 @@ esac
 # run restart sequence as transient unit...
 # it is possible to view its output in the log if any:
 # journalctl -u restart-dbus
-systemd-run -G --unit=restart-dbus --description="Transient dbus restarter" sh -c "$COMMANDS"
+systemd-run \
+	-G \
+	--unit=restart-dbus.service \
+	--description="Transient dbus restarter" \
+	--property=SyslogIdentifier=restart-dbus \
+	-- sh -xc "$COMMANDS"

--- a/ex/restart.d/dbus.service
+++ b/ex/restart.d/dbus.service
@@ -140,6 +140,7 @@ while IFS='=' read -r match_unit add_units; do
 	*" $match_unit "*)
 		# shellcheck disable=SC2086
 		for add_unit in $add_units; do
+			systemctl is-active -q "$add_unit" || continue
 			case " $ACTIVE_DEPS " in
 			*" $add_unit "*) true ;;
 			*) ACTIVE_DEPS="${ACTIVE_DEPS}${ACTIVE_DEPS:+ }${add_unit}" ;;


### PR DESCRIPTION
- Also Check for `Type=dbus` and `bus-org.*` in aliases.
- Add a list for manual conditional dependencies, since this is currently the only way to also restart `networkd-dispatcher.service` if `systemd-networkd.service` is slated for restart. It fails otherwise.
- Improved transient unit logging.