### PR TITLE
needrestart: fix container detection on rootless podman

### DIFF
--- a/needrestart
+++ b/needrestart
@@ -72,12 +72,12 @@ elsif(eval "use ImVirt; 1;") {
 	$is_vm = $imvirt ne ImVirt->IMV_PHYSICAL;
 	$is_container = $imvirt eq ImVirt->IMV_CONTAINER;
 }
-elsif (-r "/proc/1/environ") {
+elsif (-r "/proc/" . getppid() . "/environ") {
 	# check if we are inside of a container (fallback)
-    local $/;
-    open(HENV, '<', '/proc/1/environ');
-    $is_container = scalar(grep {/^container=/;} unpack("(Z*)*", <HENV>));
-    close(HENV)
+	local $/;
+	open(HENV, '<', "/proc/" . getppid() . "/environ");
+	$is_container = scalar(grep {/^container=/;} unpack("(Z*)*", <HENV>));
+	close(HENV)
 }
 
 sub HELP_MESSAGE {


### PR DESCRIPTION
Right now /proc/1/environ might not be accessible in case of rootless podman containers, in case we're not using a pid namespace, for example:

```
default_distrobox:needrestart$ sudo cat /proc/1/environ
cat: /proc/1/environ: Permission denied
default_distrobox:needrestart$ sudo /usr/sbin/needrestart
readline() on closed filehandle HENV at /usr/sbin/needrestart line 79.
Use of uninitialized value in unpack at /usr/sbin/needrestart line 79.
readline() on closed filehandle HENV at /usr/sbin/needrestart line 79.
Use of uninitialized value in unpack at /usr/sbin/needrestart line 79.
```

This PR will instead use the current process' ppid to detect environ, so we're sure we have read access to it.

This is not a breaking change, it still works on rootful podman containers, and in namespaced pids.