### PR TITLE
fix: DBUS_SESSION_BUS_ADDRESS is empty when notification is sent

### DIFF
--- a/ex/notify.d/400-notify-send
+++ b/ex/notify.d/400-notify-send
@@ -32,6 +32,8 @@ case "$NR_SESSION" in
     DBUS_SESSION_BUS_ADDRESS=$(sed -z -n s/^DBUS_SESSION_BUS_ADDRESS=//p "/proc/$NR_SESSPPID/environ")
     if [ -z "$DBUS_SESSION_BUS_ADDRESS" ]; then
         unset DBUS_SESSION_BUS_ADDRESS
+	else
+        export DBUS_SESSION_BUS_ADDRESS
     fi
 
     DISPLAY=$(sed -z -n s/^DISPLAY=//p "/proc/$NR_SESSPPID/environ")


### PR DESCRIPTION
The DBUS_SESSION_BUS_ADDRESS variable is set but won't survive entering the `runuser`. The consequence is that the active notification daemon won't receive it (and on my system a second notification daemon gets started).

This has been stated there: https://github.com/liske/needrestart/issues/76#issuecomment-1320860074