### PR TITLE
vmlinuz-get-version: implement decompression for LZ4 and ZSTD

### DIFF
--- a/lib/vmlinuz-get-version
+++ b/lib/vmlinuz-get-version
@@ -63,3 +63,5 @@ which unxz    > /dev/null && try_decompress '\3757zXZ\000' abcde unxz
 which bunzip2 > /dev/null && try_decompress 'BZh'          xy    bunzip2
 which unlzma  > /dev/null && try_decompress '\135\0\0\0'   xxx   unlzma
 which lzop    > /dev/null && try_decompress '\211\114\132' xy    'lzop -d'
+which lz4     > /dev/null && try_decompress '\002!L\030'   xxx   'lz4 -d'
+which unzstd  > /dev/null && try_decompress '(\265/\375'   xxx   unzstd


### PR DESCRIPTION
As described in the commit message, this PR implements vmlinuz decompression for LZ4 and ZSTD formats. This fixes version detection on systems with kernel images compressed in these formats.

My scenario is as follows. Two images are registered:

* `6.19.0-arch0-1-csmantle`, currently booted, my custom-built ZSTD-compressed kernel
* `6.18.9-arch1-2`, uncompressed stock kernel

The current implementation in needrestart(1) will incorrectly report the running kernel as stale:

```console
$ sudo needrestart -k
Scanning linux images...

Pending kernel upgrade!

Running kernel version:
  6.19.0-arch0-1-csmantle

Diagnostics:
  The currently running kernel version is not the expected kernel version 6.18.9-arch1-2.

Restarting the system to load the new kernel will not be handled automatically, so you should consider rebooting. [Return]
```

After applying this patch, the version detection works normally.

I have prepared [a custom Arch Linux package](https://github.com/CSharperMantle/aur-needrestart-git/) for a trial run.