### PR TITLE
Fix for processes whose information cannot be accessed.

### DIFF
--- a/needrestart
+++ b/needrestart
@@ -520,7 +520,7 @@ if(defined($opt_l)) {
 
     $ui->progress_prep(scalar keys %$ptable, __ 'Scanning processes...');
     my %stage2;
-    for my $pid (sort {$a <=> $b} keys %$ptable) {
+    for my $pid (sort {$a <=> $b} grep { /^\d+$/ } keys %$ptable) {
 	$ui->progress_step;
 
 	# user-mode: skip foreign processes


### PR DESCRIPTION
Fix for processes whose information cannot be accessed. Usually cannot be retrieved in zombie processes

Before, it was giving this output.
Argument "" isn't numeric in sort at /usr/sbin/needrestart line 523, <STDIN> line 3.