### PR TITLE
Don't let config files override -q or -v option

### DIFF
--- a/ex/needrestart.conf
+++ b/ex/needrestart.conf
@@ -239,11 +239,16 @@ $nrconf{skip_mapfiles} = -1;
 # $nrconf{'nagios-status'}->{sessions} = 0;
 
 
+# Don't let above config override -q/-v flag from command line.
+set_verbosity;
+
 # Read additional config snippets.
 if(-d q(/etc/needrestart/conf.d)) {
       foreach my $fn (sort </etc/needrestart/conf.d/*.conf>) {
 	      print STDERR "$LOGPREF eval $fn\n" if($nrconf{verbosity} > 1);
 	      eval do { local(@ARGV, $/) = $fn; <>};
 	      die "Error parsing $fn: $@" if($@);
+	      # Don't let config snippet override -q/-v flag from command line.
+	      set_verbosity;
       }
 }

--- a/needrestart
+++ b/needrestart
@@ -212,14 +212,18 @@ die "ERROR: Could not read config file '$opt_c'!\n" unless(-r $opt_c || $opt_b);
 $ENV{DEBIAN_FRONTEND} = $opt_f if($opt_f);
 my $debian_noninteractive = (exists($ENV{DEBIAN_FRONTEND}) && $ENV{DEBIAN_FRONTEND} eq 'noninteractive');
 
-# be quiet
-if($opt_q) {
-    $nrconf{verbosity} = 0;
+sub set_verbosity {
+    # be quiet
+    if($opt_q) {
+	$nrconf{verbosity} = 0;
+    }
+    # be verbose
+    elsif($opt_v) {
+	$nrconf{verbosity} = 2;
+    }
 }
-# be verbose
-elsif($opt_v) {
-    $nrconf{verbosity} = 2;
-}
+
+set_verbosity;
 
 # slurp config file
 print STDERR "$LOGPREF eval $opt_c\n" if($nrconf{verbosity} > 1);
@@ -231,6 +235,9 @@ eval do {
     $cfg;
 };
 die "Error parsing $opt_c: $@" if($@);
+
+# enforce verbosity from command line option
+set_verbosity;
 
 # fallback to stdio on verbose mode
 $nrconf{ui} = qq(NeedRestart::UI::stdio) if($nrconf{verbosity} > 1);


### PR DESCRIPTION
The current code evaluates only once (quite early) if -q or -v was given on the command line and sets $nrconf{verbosity} accordingly. The config files were evaluated after that, thereby letting them override the command line options.

It feels more correct to give the command line options the higher priority.